### PR TITLE
feat: add hipaa-validate skill

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -11,6 +11,8 @@ We welcome bug fixes, new skills, agents, hooks, and improvements. This guide ex
 5. **Push** to your fork and open a **Pull Request** against `main`
 6. The maintainer will review, pull the branch locally if needed, adjust documentation, and merge
 
+
+
 > **Note:** Documentation updates (README, ARCHITECTURE, CLAUDE.md, counts, etc.) are handled by the maintainer after merge. You do not need to update these yourself.
 
 ## Branch Naming

--- a/app/skills/hipaa-validate/SKILL.md
+++ b/app/skills/hipaa-validate/SKILL.md
@@ -1,0 +1,353 @@
+---
+name: hipaa-validate
+description: "Validate code against HIPAA policy: PHI exposure, missing audit logging, unencrypted transmission/storage, access control gaps, temp file exposure, and missing BAA references"
+effort: medium
+disable-model-invocation: true
+argument-hint: "[path] [--mode developer|compliance] [--severity high|warn] [--keywords term1,term2]"
+allowed-tools: Read, Grep, Glob
+---
+
+# /hipaa-validate - HIPAA Compliance Scanner
+
+$ARGUMENTS
+
+Scan a codebase for HIPAA compliance issues using pattern-matching heuristics. Detects PHI exposure in logs, missing audit trails, unencrypted transmission/storage, hardcoded patient data, access control gaps, and missing Business Associate Agreement references. Read-only — never modifies files.
+
+**Regulation basis**: 45 CFR Parts 160, 162, 164 (HIPAA Administrative Simplification, as amended through March 26, 2013). Covers Security Rule (§164.302-318), Privacy Rule (§164.500-534), Breach Notification Rule (§164.400-414), and enforcement penalties (§160.400-426).
+
+## Usage
+
+```
+/hipaa-validate                              # Scan full project (developer mode — definitives only)
+/hipaa-validate src/                         # Scan specific path
+/hipaa-validate --mode compliance            # Full audit sweep including heuristic categories
+/hipaa-validate --severity high              # Filter to HIGH findings only
+/hipaa-validate --keywords member,enrollee   # Extend healthcare keyword list
+```
+
+**Modes:**
+- `developer` (default): Categories 1, 3, 4, 7, 8 — definitive regex matches only, low false-positive rate, suited for daily use
+- `compliance`: All 8 categories — includes heuristic checks (Cat 2, 5, 6) for audit sweep coverage, suited for pre-audit sweeps
+
+**Severity filtering:** `--severity high` shows only HIGH findings, `--severity warn` shows HIGH + WARN. Default shows all.
+
+## What This Command Does
+
+1. **Context gate** — identify PHI-adjacent files via healthcare keyword grep
+2. **Detect** project language/framework from manifest files
+3. **Scan** for HIPAA violations across 8 check categories
+4. **Report** findings with file paths, line numbers, severity, confidence, and HIPAA rule citations
+
+## Steps
+
+### Step 0: Context Gate
+
+Grep the entire project for healthcare keywords to build a PHI-adjacent file set:
+
+**Default keywords**: `patient`, `diagnosis`, `medication`, `clinical`, `healthcare`, `medical`, `fhir`, `hl7`, `hipaa`, `phi`, `protected.health`, `health-record`, `health-plan`, `health-insurance`
+
+> **Note**: Bare `health` is deliberately excluded — it matches infrastructure health checks (`healthCheck`, `/health`, `isHealthy`) in nearly every codebase. Only compound healthcare terms are used.
+
+If `--keywords` is passed, merge those terms into the default list.
+
+If **zero files match**, report:
+
+```
+No healthcare context detected.
+Keywords searched: patient, diagnosis, medication, clinical, healthcare, medical, fhir, hl7, hipaa, phi, protected.health, health-record, health-plan, health-insurance
+If your project uses different terminology (e.g., member, enrollee, beneficiary, subscriber, resident, subject, claimant), re-run with:
+  /hipaa-validate --keywords member,enrollee,...
+```
+
+And exit clean — no findings.
+
+**Built-in file exclusions** (always skipped):
+- Binary files, lock files (`*.lock`, `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`)
+- Vendored directories (`node_modules/`, `vendor/`, `.git/`, `dist/`, `build/`, `out/`, `.next/`)
+
+**`.hipaaignore` support**: If a `.hipaaignore` file exists at project root, read it and exclude matching paths. Format follows `.gitignore` syntax — one glob pattern per line, `#` for comments. Example:
+
+```
+# Synthetic test data
+tests/fixtures/**
+seed/demo-data.sql
+```
+
+**Scope check**: After building the PHI-adjacent file set, count files. If count > 50, emit this warning in the Summary header before proceeding:
+
+> ⚠️ Large scope: N PHI-adjacent files detected. Analysis may be incomplete due to context limits. Consider narrowing: `/hipaa-validate src/api/` for targeted results.
+
+### Step 1: Detect Language/Framework
+
+| Indicator | Language | Log Patterns | Framework Hints |
+|-----------|----------|--------------|-----------------|
+| `package.json` | JS/TS | `console.*`, `logger.*` | Express, Next.js, Fastify |
+| `requirements.txt` / `pyproject.toml` | Python | `print(`, `logging.*` | Django, FastAPI, Flask |
+| `*.go` / `go.mod` | Go | `fmt.Print`, `log.*` | net/http, gin, echo |
+| `*.java` / `pom.xml` | Java | `System.out`, `Logger.*` | Spring Boot |
+| `*.rb` / `Gemfile` | Ruby | `puts`, `Rails.logger` | Rails |
+| `*.cs` / `*.csproj` | C# | `Console.Write`, `ILogger` | ASP.NET |
+
+### Step 2: Run Check Categories
+
+**Mode: developer (default)**: Run Categories 1, 3, 4, 7, 8 only — definitive regex matches, minimal false positives.
+**Mode: compliance**: Run all 8 categories — Categories 2, 5, 6 are heuristic and expected to produce false positives.
+
+Categories 1 and 2 scan the full project (patterns are inherently healthcare-scoped).
+Categories 3, 4, 5, 6, 7, and 8 scan only the PHI-adjacent file set from Step 0.
+
+---
+
+#### Category 1: PHI in Logs/Console Output
+
+Scan the full project for log/print statements that reference PHI keywords.
+
+| Pattern | Severity | Language | Description |
+|---------|----------|----------|-------------|
+| `console\.log\(.*patient` | HIGH | JS/TS | Patient data in console |
+| `console\.\w+\(.*req\.body` | WARN | JS/TS | Raw request body may contain PHI |
+| `JSON\.stringify\(.*patient` | WARN | JS/TS | Full patient object serialization |
+| `print\(.*\b(patient\|ssn\|social.security)` | HIGH | Python | PHI in print statements |
+| `logging\.\w+\(.*\b(patient\|ssn\|mrn\|dob)` | HIGH | Python | PHI fields in logger calls |
+| `fmt\.Print.*\b(patient\|ssn\|mrn)` | HIGH | Go | PHI in fmt output |
+| `log\.\w+\(.*\b(patient\|ssn\|mrn)` | HIGH | Go/Any | PHI in log calls |
+| `System\.out\.print.*\b(patient\|ssn\|mrn)` | HIGH | Java | PHI in stdout |
+| `logger\.\w+\(.*\b(patient\|ssn\|mrn\|dob)` | HIGH | Java/Any | PHI fields in logger |
+| `puts.*\b(patient\|ssn\|mrn)` | HIGH | Ruby | PHI in puts |
+| `Rails\.logger.*\b(patient\|ssn\|mrn)` | HIGH | Ruby | PHI in Rails logger |
+| `Console\.Write.*\b(patient\|ssn\|mrn)` | HIGH | C# | PHI in Console output |
+| `_logger\.\w+\(.*\b(patient\|ssn\|mrn\|dob)` | HIGH | C# | PHI in ILogger calls |
+
+> **Language coverage note**: JS/TS patterns are the most comprehensive. Go, Ruby, and Java have baseline coverage for common log patterns. Contributions for additional language-specific patterns are welcome.
+
+**Minimum Necessary violations** (§164.502(b)):
+
+| Pattern | Severity | Language | Description |
+|---------|----------|----------|-------------|
+| `res\.(json\|send)\(.*patient` without field projection | WARN | JS/TS | Full patient object in API response |
+| `return.*patient` in route handler without field selection | WARN | Any | May expose unnecessary PHI fields |
+| `SELECT\s+\*.*FROM.*(patient\|member\|enrollee)` | WARN | SQL | SELECT * on PHI tables violates minimum necessary |
+| `JSON\.stringify\(.*patient` | WARN | JS/TS | Full patient object serialization |
+| `json\.dumps\(.*patient` | WARN | Python | Full patient object serialization |
+| `JsonConvert\.Serialize.*patient` | WARN | C# | Full patient object serialization |
+
+---
+
+#### Category 2: Missing Audit Logging
+
+*Compliance mode only. Heuristic — flags potential gaps, not definitive findings.*
+
+> **Developer mode**: This category is skipped. Run with `--mode compliance` to include audit gap checks.
+
+Scan the full project for files that handle PHI data operations but lack audit-related keywords.
+
+**PHI route file definition**: A file qualifies if it contains BOTH:
+1. A healthcare keyword from Step 0 (`patient`, `diagnosis`, `medication`, etc.)
+2. A data operation pattern: `router`, `app.get`, `app.post`, `app.put`, `app.delete`, `@RequestMapping`, `@GetMapping`, `@PostMapping`, `@PutMapping`, `@DeleteMapping`, `Model.find`, `Model.save`, `Model.update`, `db.query`, `db.execute`, `cursor.execute`, `repository.`, `findBy`, `save(`, `delete(`
+
+Files with a healthcare keyword but no data operation pattern are excluded.
+
+**Audit keywords** (co-occurrence check): `audit`, `AuditEvent`, `auditLog`, `logAccess`, `logEvent`, `createAuditEntry`, `recordAccess`, `ActivityLog`, `trail`, `writeAudit`
+
+| Pattern | Severity | Description |
+|---------|----------|-------------|
+| PHI route file without any audit keywords in same file | HIGH | §164.312(b) — POTENTIAL audit gap: verify audit controls exist in call chain |
+| CRUD operations on patient resources without audit keywords in same file | HIGH | POTENTIAL gap: all PHI access must be logged |
+| Admin operations without audit trail reference | WARN | POTENTIAL gap: administrative actions need recording |
+| Bulk data operations (`export`, `download`, `bulk`, `batch`) on PHI resources without audit keywords in same file | HIGH | POTENTIAL gap: mass PHI access must be tracked |
+
+> **Note**: This category uses co-occurrence heuristics — checking whether PHI route keywords and audit keywords appear in the same file. False positives are expected when audit logging is handled by middleware or a separate call chain. Use `.hipaaignore` to suppress confirmed false positives.
+
+See: [reference/hipaa-rules.md](reference/hipaa-rules.md) §164.312(b) for audit control requirements.
+
+---
+
+#### Category 3: Unencrypted PHI Transmission
+
+*Context-gated: scans PHI-adjacent files only.*
+
+| Pattern | Severity | Description |
+|---------|----------|-------------|
+| `http://` in API calls (not `localhost`/`127.0.0.1`) | HIGH | §164.312(e)(1) requires encryption in transit |
+| Missing TLS/SSL config in database connections | HIGH | Database connections must be encrypted |
+| `rejectUnauthorized:\s*false` | HIGH | TLS verification disabled |
+| `ws://` (WebSocket without TLS) | WARN | Unencrypted WebSocket may carry PHI |
+| Email sending without TLS config | WARN | PHI in email must use TLS |
+
+See: [reference/hipaa-rules.md](reference/hipaa-rules.md) §164.312(e)(1) for transmission security requirements.
+
+---
+
+#### Category 4: Hardcoded PHI/Test Data
+
+*Context-gated: scans PHI-adjacent files only.*
+
+**Built-in test directory exclusions**: Skip files in `test/`, `tests/`, `__tests__/`, `spec/`, `fixtures/`, `mocks/`, `__mocks__/`, `testdata/`, `test-data/` — test fixtures legitimately contain synthetic PHI.
+
+| Pattern | Severity | Description |
+|---------|----------|-------------|
+| `\d{3}-\d{2}-\d{4}` in PHI-adjacent source files | HIGH | Hardcoded SSNs |
+| MRN patterns near healthcare keywords | HIGH | Medical record numbers in code |
+| `\b\d{5}(-\d{4})?\b` near `zip\|postal\|address` keywords | WARN | ZIP codes in healthcare context (§164.514(b)(2)(i)(B)) |
+| Real-looking patient names in seed/fixture data | WARN | Use synthetic data generators |
+| Date of birth + name co-occurrence in same file | WARN | Combined identifiers = PHI |
+| Phone/email/IP regex matches in PHI-adjacent files | WARN | HIPAA identifiers in healthcare context |
+| `\d{3}[\s.-]?\d{3}[\s.-]?\d{4}` near `phone` keyword | WARN | Phone numbers in healthcare context |
+
+See: [reference/phi-identifiers.md](reference/phi-identifiers.md) for the full list of 18 HIPAA identifiers and detection patterns.
+
+---
+
+#### Category 5: Access Control Gaps
+
+*Context-gated: scans PHI-adjacent files only. Heuristic — flags potential gaps.*
+
+**Auth keywords** (co-occurrence check): `auth`, `authenticate`, `requireAuth`, `isAuthenticated`, `protect`, `guard`, `Authorize`, `login_required`, `Permission`
+
+| Pattern | Severity | Description |
+|---------|----------|-------------|
+| PHI route file without any auth keywords in same file | WARN | POTENTIAL access control gap — verify auth middleware covers these routes (§164.312(d)) |
+| `Access-Control-Allow-Origin:\s*\*` or `origin:\s*(true\|\*)` in PHI-adjacent files | HIGH | Unrestricted cross-origin access to PHI endpoints |
+| Routes marked `public`, `noAuth`, `anonymous` exposing PHI keywords | HIGH | PHI must require authentication |
+
+> **Note**: Auth middleware is commonly applied at router-level or app-level. The co-occurrence heuristic checks the same file only. False positives expected when auth is configured globally. Use `.hipaaignore` to suppress.
+
+See: [reference/hipaa-rules.md](reference/hipaa-rules.md) §164.312(a)(1) and §164.312(d) for access control and authentication requirements.
+
+---
+
+#### Category 6: Missing BAA References
+
+*Compliance mode only. Context-gated: scans PHI-adjacent files only.*
+
+> **Developer mode**: This category is skipped. Run with `--mode compliance` to include BAA checks.
+
+Instead of per-finding rows, emit a single **BAA Verification Checklist** in the compliance report:
+
+1. Grep PHI-adjacent files for HTTP client calls (`fetch(`, `axios.`, `requests.`, `http.Get`, `HttpClient`, `RestTemplate`, `urllib`). Extract external domains.
+2. Grep for cloud storage calls (`S3`, `GCS`, `BlobStorage`, `putObject`, `upload`). Note each service.
+3. Grep for cloud database connections (`mongodb+srv://`, `postgres://`, `mysql://`, `firestore`, `dynamodb`, `CosmosClient`, `MongoClient`, connection strings with cloud hostnames). Note each service.
+4. Grep for message queue / event streaming services (`SQS`, `SNS`, `RabbitMQ`, `redis://`, `kafka`, `EventBridge`, `PubSub`). Note each service.
+5. Grep for CDN references (`CloudFront`, `Cloudflare`, `Akamai`, `Fastly`, `cdn.`) serving PHI-adjacent paths. Note each service.
+6. Grep for observability / logging SDKs (`datadog`, `splunk`, `newrelic`, `sentry`, `logstash`, `elasticsearch`, `bugsnag`, `rollbar`). Note each SDK.
+7. Grep for analytics SDK calls (`analytics.`, `gtag`, `mixpanel`, `segment`, `amplitude`, `posthog`). Note each SDK.
+8. Read `.hipaa-config` at project root if it exists. Suppress vendors listed under `covered_vendors`.
+9. Emit one checklist row per unverified domain/service.
+
+**`.hipaa-config` format** (suppress known-covered vendors):
+```json
+{
+  "covered_vendors": ["aws", "twilio", "sendgrid", "stripe"]
+}
+```
+
+**Output format for compliance mode**:
+```
+### BAA Verification Checklist
+| Service/Domain | Pattern Detected | BAA Status |
+|----------------|-----------------|------------|
+| AWS S3 | `putObject` in src/storage/patient-files.ts | ✓ covered (covered_vendors) |
+| sendgrid.com | `axios.post` in src/notifications/email.ts | ⚠️ verify BAA exists |
+| analytics.google.com | `gtag` in src/components/Dashboard.tsx | ❌ verify no PHI flows here |
+```
+
+> **Note**: This is a documentation checklist, not a legal review. Items marked ⚠️ or ❌ require human verification, not code changes.
+
+---
+
+#### Category 7: Encryption at Rest
+
+*Context-gated: scans PHI-adjacent files only. Developer mode.*
+
+Detects PHI storage patterns without encryption references. Per §164.312(a)(2)(iv), ePHI must be encrypted when stored.
+
+| Pattern | Severity | Description |
+|---------|----------|-------------|
+| `encrypt\s*[:=]\s*false` in database config files | HIGH | §164.312(a)(2)(iv) — Encryption explicitly disabled |
+| File write operations (`writeFile`, `fs.write`, `open(.*w`, `File.Create`) in PHI-adjacent code without encryption references | WARN | PHI written to disk may lack encryption at rest |
+| Database connection without `ssl`, `encrypt`, or `tls` keywords in PHI-adjacent config | WARN | Database storing PHI should enforce encrypted connections |
+| `localStorage.setItem` or `sessionStorage.setItem` with PHI keywords | HIGH | Browser storage is unencrypted — PHI must not be stored client-side without encryption |
+| `SharedPreferences` or `UserDefaults` with PHI keywords | HIGH | Mobile local storage is unencrypted by default |
+
+See: [reference/hipaa-rules.md](reference/hipaa-rules.md) §164.312(a)(2)(iv) for encryption requirements.
+
+---
+
+#### Category 8: PHI Temp File Exposure
+
+*Context-gated: scans PHI-adjacent files only. Developer mode.*
+
+Detects temporary file creation in PHI-adjacent code without secure deletion. Per §164.310(d)(2)(iii), media containing PHI must be sanitized before reuse or disposal.
+
+| Pattern | Severity | Description |
+|---------|----------|-------------|
+| `/tmp/` or `tempfile\.` or `os\.tmpdir\(\)` or `Path\.GetTempPath` in PHI-adjacent code | WARN | §164.310(d)(2)(iii) — Temp files with PHI must be securely deleted |
+| `mktemp` or `NamedTemporaryFile` or `createTempFile` near PHI keywords | WARN | Verify temp files are cleaned up after use |
+| Cache directory writes (`cache/`, `.cache`, `Cache.set`) with PHI keywords | WARN | Cached PHI must be encrypted or purged on schedule |
+
+See: [reference/hipaa-rules.md](reference/hipaa-rules.md) §164.310(d)(2)(iii) for disposal requirements.
+
+### Step 3: Compile and Report
+
+Parse all findings into the unified output format below. Sort by severity (HIGH first), then by file path.
+
+## Output Format
+
+```markdown
+## HIPAA Validation Report
+
+### Summary
+| Metric | Value |
+|--------|-------|
+| Mode | developer / compliance |
+| PHI-adjacent files | N |
+| Files scanned | N |
+| Categories run | 1,3,4,7,8 (developer) / 1,2,3,4,5,6,7,8 (compliance) |
+| Severity HIGH | N |
+| Severity WARN | N |
+
+### Findings
+
+#### [HIGH] src/api/patients.ts:42
+Category: PHI in Logs
+Confidence: definitive (regex match)
+Pattern: `console.log(patient.name)`
+HIPAA Rule: §164.502(b) — Minimum Necessary Standard
+Fix: Replace with `safeLog()` or remove PHI from log output
+
+#### [HIGH] src/routes/patient-api.ts:15
+Category: Missing Audit Logging
+Confidence: heuristic (co-occurrence check — may be false positive)
+Pattern: PHI route file without audit keywords
+HIPAA Rule: §164.312(b) — Audit Controls
+Fix: Verify audit logging exists in call chain; add AuditEvent creation if missing
+
+#### [WARN] src/services/patient-sync.ts:88
+Category: Unencrypted PHI Transmission
+Confidence: definitive (regex match)
+Pattern: `http://external-api.example.com/patients`
+HIPAA Rule: §164.312(e)(1) — Transmission Security
+Fix: Use HTTPS for all PHI transmission
+```
+
+**Confidence values**:
+- `definitive` — Categories 1, 3, 4, 7, 8: regex matched actual code
+- `heuristic` — Categories 2, 5, 6: co-occurrence/absence check, may be false positive
+
+This distinction helps compliance officers prioritize immediate remediation (definitive) vs. investigation (heuristic).
+
+## Rules
+
+- **Read-only**: Never modify any files. Report findings only.
+- **HIPAA rule citation**: Every finding must reference a specific HIPAA section (§ number).
+- **Skip non-source files**: Binary files, lock files (`*.lock`, `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`), vendored directories (`node_modules/`, `vendor/`, `.git/`, `dist/`, `build/`, `out/`, `.next/`).
+- **Respect `.hipaaignore`**: Honor exclusion patterns in the project's `.hipaaignore` file.
+- **No false confidence**: Clearly label heuristic findings as `POTENTIAL` and mark confidence as `heuristic`.
+- **Context before identifiers**: Always run the healthcare keyword context gate before applying PHI identifier regex patterns (Category 4) to avoid false positives.
+- **Warn on missing secrets management**: Flag PHI-adjacent config files without `.env` or secret manager references.
+- **No auto-fix in v1**: Auto-fixing HIPAA issues requires project-specific knowledge of logging/audit infrastructure. Planned for v2.
+
+## Reference Documents
+
+- [reference/hipaa-rules.md](reference/hipaa-rules.md) — HIPAA Security Rule, Privacy Rule, and Breach Notification Rule mapped to technical controls
+- [reference/phi-identifiers.md](reference/phi-identifiers.md) — The 18 HIPAA identifiers with detection patterns and detectability status

--- a/app/skills/hipaa-validate/reference/hipaa-rules.md
+++ b/app/skills/hipaa-validate/reference/hipaa-rules.md
@@ -1,0 +1,303 @@
+# HIPAA Rules Reference
+
+Technical controls mapping for the HIPAA Security Rule, Privacy Rule, and Breach Notification Rule. Used by the `hipaa-validate` skill to cite specific regulatory sections in findings.
+
+## Enforcement — 45 CFR Part 160, §160.404
+
+The enforcement rule establishes civil money penalty tiers for HIPAA violations. Understanding penalty exposure helps teams prioritize remediation.
+
+### Penalty Tiers (§160.404(b)(2))
+
+| Tier | Knowledge Level | Per Violation | Annual Maximum |
+|------|----------------|---------------|----------------|
+| 1 | Did not know (and reasonable diligence would not have revealed) | $100 – $50,000 | $1,500,000 |
+| 2 | Reasonable cause, not willful neglect | $1,000 – $50,000 | $1,500,000 |
+| 3 | Willful neglect, corrected within 30 days | $10,000 – $50,000 | $1,500,000 |
+| 4 | Willful neglect, not timely corrected | $50,000 minimum | $1,500,000 |
+
+**How this maps to scan findings**:
+- HIGH findings with `definitive` confidence (Categories 1, 3, 4, 7, 8) typically represent Tier 2-3 exposure — the organization "should have known" via reasonable diligence
+- Unresolved findings after notification represent potential Tier 3-4 exposure
+- Heuristic findings (Categories 2, 5, 6) require investigation before tier assessment
+
+### Statute of Limitations (§160.414)
+
+Actions must be commenced within **6 years** from the date of occurrence. Continuing violations accrue a separate violation each day (§160.406).
+
+## Security Rule — 45 CFR §164.302-318
+
+The Security Rule establishes national standards for protecting electronic Protected Health Information (ePHI).
+
+### §164.306 — General Rules (Flexibility of Approach)
+
+**Requirement**: Covered entities must assess potential risks and vulnerabilities and implement security measures sufficient to reduce risks to a reasonable and appropriate level. The rule allows flexibility — entities may use any security measures that allow them to reasonably and appropriately implement the standards.
+
+**Why this matters for scanning**:
+- Heuristic findings (Categories 2, 5, 6) flag *potential* gaps — organizations may satisfy the requirement through alternative means not detectable by file-level co-occurrence checks
+- The standard is "reasonable and appropriate" — not prescriptive technology mandates
+- Entity size, complexity, and capabilities should be factored when assessing findings
+
+**Detectable by**: Not directly scanned. Referenced in heuristic confidence disclaimers to prevent over-weighting.
+
+### §164.308 — Administrative Safeguards
+
+**Requirement**: Administrative actions, policies, and procedures to manage the selection, development, implementation, and maintenance of security measures to protect ePHI.
+
+This is the most frequently cited section in HIPAA enforcement actions. While primarily policy-driven, several subsections have code-detectable implications.
+
+#### §164.308(a)(1)(i) — Security Management Process
+
+Implement policies to prevent, detect, contain, and correct security violations. Includes risk analysis and risk management.
+
+**Code implications**:
+- Security scanning should be part of CI/CD pipeline
+- Risk assessment documentation should exist for PHI-handling systems
+- Vulnerability management process for dependencies
+
+**Detectable by**: Not directly scanned. Presence of security policy docs (`SECURITY.md`, `security-policy.*`) may be checked in compliance mode.
+
+#### §164.308(a)(3) — Workforce Security
+
+Implement policies to ensure workforce members have appropriate access to ePHI and prevent unauthorized access.
+
+**Code implications**:
+- Role-based access control (RBAC) implementation
+- Principle of least privilege in permission models
+- Access termination procedures when workforce members leave
+
+**Detectable by**: Category 5 (Access Control Gaps — partial). Auth keyword checks detect missing access control but cannot verify least-privilege enforcement.
+
+#### §164.308(a)(5) — Security Awareness and Training
+
+Implement a security awareness and training program for all workforce members.
+
+**Code implications**:
+- Not directly code-scannable
+- Security documentation and onboarding materials should reference PHI handling procedures
+
+**Detectable by**: Not directly scanned. Informational reference.
+
+#### §164.308(a)(6) — Security Incident Procedures
+
+Implement policies and procedures to address security incidents. Includes identifying, responding to, mitigating, and documenting incidents.
+
+**Code implications**:
+- Incident response runbooks should exist
+- Security event monitoring and alerting should be configured
+- Incident logging should be separate from application logging
+
+**Detectable by**: Not directly scanned. Compliance officers should verify incident response documentation exists.
+
+#### §164.308(b)(1) — Business Associate Contracts
+
+Covered entities must obtain satisfactory assurances from business associates that they will appropriately safeguard ePHI, implemented through BAA contracts.
+
+**Code implications**:
+- Every third-party service that receives, creates, maintains, or transmits PHI requires a BAA
+- This includes cloud providers, analytics services, email services, database providers, CDN services, message queues, and observability platforms
+
+**Detectable by**: Category 6 (Missing BAA References)
+
+### §164.310 — Physical Safeguards
+
+**Requirement**: Physical measures, policies, and procedures to protect electronic information systems and related buildings and equipment from natural and environmental hazards and unauthorized intrusion.
+
+While primarily about physical security, several subsections have code implications.
+
+#### §164.310(d)(2)(iii) — Device and Media Controls: Disposal
+
+**Requirement**: Implement procedures for removal of ePHI from electronic media before the media are made available for re-use.
+
+**Code implications**:
+- Temporary files containing PHI must be securely deleted after use
+- Cache files with PHI must be purged on schedule
+- Application teardown/cleanup must not leave PHI artifacts on disk
+- Database exports and backups must follow secure disposal procedures
+
+**Detectable by**: Category 8 (PHI Temp File Exposure)
+
+#### §164.310(d)(2)(iv) — Device and Media Controls: Data Backup and Storage
+
+**Requirement**: Create a retrievable, exact copy of ePHI when needed, before movement of equipment.
+
+**Code implications**:
+- Backup procedures for PHI data stores
+- Not directly code-scannable — operational procedure
+
+**Detectable by**: Not directly scanned. Informational reference.
+
+### §164.312(a)(1) — Access Control
+
+**Requirement**: Implement technical policies and procedures that allow only authorized persons to access ePHI.
+
+**Technical controls**:
+- Authentication middleware on all PHI-serving routes
+- Role-Based Access Control (RBAC) or Attribute-Based Access Control (ABAC)
+- Session management with appropriate timeouts
+- No wildcard CORS (`Access-Control-Allow-Origin: *`) on PHI endpoints
+- No `public`, `noAuth`, or `anonymous` route decorators on PHI endpoints
+
+**Detectable by**: Category 5 (Access Control Gaps)
+
+### §164.312(a)(2)(iv) — Encryption and Decryption (Access Control Implementation)
+
+**Requirement**: Implement a mechanism to encrypt and decrypt ePHI.
+
+**Technical controls**:
+- Encryption at rest for all PHI data stores (database-level or application-level encryption)
+- Encrypted file storage for PHI documents
+- No plaintext PHI in browser `localStorage` or `sessionStorage`
+- No plaintext PHI in mobile local storage (`SharedPreferences`, `UserDefaults`) without encryption layer
+- Encryption keys managed via KMS, not hardcoded
+- `encrypt: false` explicitly disabling encryption in database configs
+
+**Detectable by**: Category 7 (Encryption at Rest)
+
+### §164.312(b) — Audit Controls
+
+**Requirement**: Implement hardware, software, and/or procedural mechanisms to record and examine access and other activity in information systems that contain or use ePHI.
+
+**Technical controls**:
+- AuditEvent / audit log creation on every PHI read, write, update, delete
+- Audit trail for administrative operations (user management, permission changes)
+- Audit logging for bulk data exports and batch operations
+- Log retention policies (minimum 6 years per §164.530(j))
+- Tamper-evident audit storage (append-only, separate from application data)
+
+**Detectable by**: Category 2 (Missing Audit Logging)
+
+### §164.312(c)(1) — Integrity Controls
+
+**Requirement**: Implement policies and procedures to protect ePHI from improper alteration or destruction.
+
+**Technical controls**:
+- Input validation and sanitization on PHI fields
+- Data integrity checksums for stored PHI
+- Database constraints (NOT NULL, CHECK, foreign keys) on PHI tables
+- Version control / soft-delete for PHI records
+- Optimistic concurrency control for PHI updates
+
+**Detectable by**: Partially detectable — `DELETE FROM.*patient` without soft-delete pattern, missing input validation on PHI route handlers. Full coverage planned for future category.
+
+### §164.312(d) — Person or Entity Authentication
+
+**Requirement**: Implement procedures to verify that a person or entity seeking access to ePHI is who they claim to be.
+
+**Technical controls**:
+- Multi-factor authentication (MFA) for PHI access
+- Strong password policies
+- Token-based authentication (JWT, OAuth2) with appropriate expiration
+- Session invalidation on logout
+- Failed login attempt limiting
+
+**Detectable by**: Category 5 (Access Control Gaps — partial)
+
+### §164.312(e)(1) — Transmission Security
+
+**Requirement**: Implement technical security measures to guard against unauthorized access to ePHI being transmitted over an electronic communications network.
+
+**Technical controls**:
+- TLS 1.2+ for all API calls transmitting PHI
+- HTTPS (never HTTP) for PHI endpoints
+- `wss://` (never `ws://`) for WebSocket connections carrying PHI
+- TLS-enabled database connections (`ssl: true`, `sslmode: require`)
+- TLS for email transport when PHI is included
+- `rejectUnauthorized: true` (never `false`) for TLS certificate verification
+
+**Detectable by**: Category 3 (Unencrypted PHI Transmission)
+
+### §164.314(a) — Organizational Requirements: Business Associate Contracts
+
+**Requirement**: A covered entity may permit a business associate to create, receive, maintain, or transmit ePHI on its behalf only if the covered entity obtains satisfactory assurances, in the form of a written contract (BAA), that the business associate will appropriately safeguard the information.
+
+**Scope of BAA requirement** (per §164.314(a)(2)(i)):
+- Every subcontractor that creates, receives, maintains, or transmits PHI
+- Cloud infrastructure providers (AWS, GCP, Azure) storing PHI
+- Database-as-a-service providers (MongoDB Atlas, RDS, Firestore)
+- Message queue / event services handling PHI events
+- CDN services delivering PHI content
+- Email / SMS services transmitting PHI notifications
+- Observability platforms receiving PHI in logs or traces
+- Analytics services if any PHI flows to them
+
+**Detectable by**: Category 6 (Missing BAA References — BAA Verification Checklist)
+
+### §164.316 — Policies and Procedures and Documentation Requirements
+
+**Requirement**: Implement reasonable and appropriate policies and procedures to comply with the Security Rule standards and implementation specifications. Maintain written (which may be electronic) documentation of policies and procedures. Retain documentation for **6 years** from the date of its creation or the date when it last was in effect, whichever is later.
+
+**Code implications**:
+- Security policies should be documented and version-controlled
+- Policy documents (`SECURITY.md`, `HIPAA.md`, `security-policy.*`, `hipaa-policy.*`) should exist in the project
+- Audit log retention must be configured for minimum 6 years
+- Changes to security configurations should be tracked in version control
+- Documentation must be available to persons responsible for implementing the procedures
+
+**Detectable by**: Compliance mode — check for presence of security policy documents in project root. Informational for developer mode.
+
+## Privacy Rule — 45 CFR §164.502, §164.514, §164.530
+
+The Privacy Rule establishes standards for the use and disclosure of PHI. While primarily administrative, several provisions have direct code implications.
+
+### §164.502(b) — Minimum Necessary Standard
+
+**Requirement**: When using or disclosing PHI, a covered entity or business associate must make reasonable efforts to limit PHI to the minimum necessary to accomplish the intended purpose of the use, disclosure, or request.
+
+**Code implications**:
+- API responses should return only required PHI fields, not entire patient objects
+- Log output must not contain PHI unless explicitly needed for debugging (and then only via safe logging)
+- Database queries should SELECT specific columns, not `SELECT *` on PHI tables
+- Data exports should filter to requested fields only
+- Full-object serialization (`JSON.stringify(patient)`, `json.dumps(patient)`) in responses or logs violates minimum necessary
+
+**Detectable by**: Category 1 (PHI in Logs — detects full-object serialization and PHI keyword patterns; also detects SELECT * and full-object API responses)
+
+### §164.514 — De-identification
+
+**Requirement**: PHI can be de-identified via Safe Harbor method (removing all 18 identifiers) or Expert Determination method.
+
+**Code implications**:
+- No hardcoded real patient data in source code, seed files, or fixtures
+- Test data must use synthetic generators, not real patient records
+- Analytics and reporting pipelines must de-identify before transmission to third parties
+- The 18 HIPAA identifiers define what constitutes PHI — see [phi-identifiers.md](phi-identifiers.md)
+
+**Detectable by**: Category 4 (Hardcoded PHI/Test Data)
+
+### §164.530(j)(2) — Documentation and Record Retention
+
+**Requirement**: Retain required documentation for 6 years from the date of its creation or the date when it was last in effect, whichever is later.
+
+**Code implications**:
+- Audit log retention policies must be configured for minimum 6-year retention
+- PHI-related documentation (BAAs, policies) must be version-controlled
+- Log rotation must not delete audit records prematurely
+
+**Detectable by**: Not directly scanned. Informational reference for audit logging findings.
+
+## Breach Notification Rule — 45 CFR §164.408-414
+
+The Breach Notification Rule requires covered entities and business associates to notify affected individuals, HHS, and (in some cases) media following a breach of unsecured PHI.
+
+### §164.408-410 — Notification Requirements
+
+**Requirement**: Following discovery of a breach of unsecured PHI:
+- Individual notification within 60 days of discovery
+- HHS notification (annually if < 500 affected; within 60 days if ≥ 500)
+- Media notification if ≥ 500 individuals in a single state/jurisdiction
+
+### §164.412 — Law Enforcement Delay
+
+**Requirement**: Notification may be delayed if law enforcement determines it would impede a criminal investigation.
+
+### §164.414 — Administrative Requirements
+
+**Requirement**: Maintain documentation of breach investigations, risk assessments, and notifications for 6 years.
+
+**Code implications**:
+- Not directly code-scannable, but included for awareness
+- PHI exposure findings from this skill represent *potential* breach vectors
+- Teams should understand that unresolved HIGH findings could lead to breach notification obligations if exploited
+- Encryption of PHI at rest and in transit is the primary defense — "unsecured PHI" means unencrypted PHI
+
+> **Note**: This rule is not scanned programmatically. It is referenced here so development teams understand the downstream consequences of PHI exposure findings detected by other categories.

--- a/app/skills/hipaa-validate/reference/phi-identifiers.md
+++ b/app/skills/hipaa-validate/reference/phi-identifiers.md
@@ -1,0 +1,45 @@
+# HIPAA PHI Identifiers
+
+The 18 identifiers defined by HIPAA's Safe Harbor de-identification method (45 CFR §164.514(b)(2)). Removing all 18 from a dataset renders it de-identified under Safe Harbor.
+
+Used by the `hipaa-validate` skill (Category 4) to detect hardcoded PHI in source code.
+
+## Identifier Reference
+
+| # | Identifier | Detectable | Detection Pattern | Notes |
+|---|-----------|------------|-------------------|-------|
+| 1 | Names | Partial | Co-occurrence of name-like strings (`firstName`, `lastName`, `patientName`) near healthcare keywords | Cannot detect arbitrary proper names; detects field names referencing patient names |
+| 2 | Geographic data (smaller than state) | Partial | `\b\d{5}(-\d{4})?\b` near `zip\|postal\|address\|zipCode\|zip_code` keywords in PHI-adjacent files | Detects ZIP codes near address-related keywords; cannot detect arbitrary city/street names. Context-gated to reduce false positives |
+| 3 | Dates (except year) | Partial | `\b(dob\|dateOfBirth\|birthDate\|birth_date\|date_of_birth)\b` near assignment/value | Detects date-of-birth field references; cannot distinguish real vs. synthetic dates |
+| 4 | Phone numbers | Yes | `\d{3}[\s.-]?\d{3}[\s.-]?\d{4}` near `phone\|tel\|mobile\|cell\|contact` keywords | Context-gated to PHI-adjacent files to reduce false positives |
+| 5 | Fax numbers | Partial | Same pattern as phone, near `fax` keyword | Rarely seen in modern code |
+| 6 | Email addresses | Yes | `[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}` in PHI-adjacent files | High false-positive rate without context gating |
+| 7 | Social Security Numbers | Yes | `\d{3}-\d{2}-\d{4}` in PHI-adjacent files | Primary detection target. Context gate critical — pattern matches version strings and dates |
+| 8 | Medical Record Numbers | Yes | `\b(mrn\|medical.record.number\|medicalRecordNumber\|medical_record)\b` near alphanumeric values | Detects MRN field references and assignments |
+| 9 | Health plan beneficiary numbers | No | — | Plan-specific formats vary. Manual review required |
+| 10 | Account numbers | No | — | Too generic to detect without healthcare context. Manual review required |
+| 11 | Certificate/license numbers | No | — | State-specific formats. Manual review required |
+| 12 | Vehicle identifiers (VIN, plates) | No | — | Not typically in healthcare code. Manual review required |
+| 13 | Device identifiers (UDI, serial numbers) | No | — | Medical device context required. Manual review required |
+| 14 | Web URLs | No | — | Too common in code. Manual review required for patient-specific URLs |
+| 15 | IP addresses | Yes | `\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b` in PHI-adjacent files, excluding `127.0.0.1`, `0.0.0.0`, `localhost` | Context-gated; only flagged in healthcare files |
+| 16 | Biometric identifiers | No | — | Fingerprints, voiceprints, retinal scans. Manual review required |
+| 17 | Full-face photographs | No | — | Image content analysis out of scope. Manual review required |
+| 18 | Any other unique identifying number | No | — | Catch-all category. Manual review required |
+
+## Detection Summary
+
+| Category | Count | Detection Method |
+|----------|-------|-----------------|
+| Detectable by regex | 7 | SSN, phone, email, IP, MRN, DOB, ZIP code patterns with context gating |
+| Policy-only (manual review) | 11 | Listed for awareness — no automated detection possible |
+
+## Usage in hipaa-validate
+
+Category 4 (Hardcoded PHI/Test Data) applies these patterns only to files identified as PHI-adjacent by the Step 0 context gate. This two-phase approach prevents false positives from:
+- Email addresses in user authentication code
+- IP addresses in infrastructure/networking code
+- Phone number patterns in non-healthcare validation logic
+- SSN-like patterns in version strings or date formats
+
+Test directories (`test/`, `tests/`, `__tests__/`, `spec/`, `fixtures/`, `mocks/`) are automatically excluded since test fixtures legitimately contain synthetic PHI data.


### PR DESCRIPTION
## Summary

Add `hipaa-validate` skill — a read-only HIPAA compliance scanner that detects PHI exposure in logs, missing audit trails, unencrypted transmission/storage, hardcoded patient data, access control gaps, and missing BAA references across 8 check categories.

Includes reference documents mapping 45 CFR Parts 160/162/164 to technical controls and the 18 HIPAA identifiers with detection patterns.

## Type of Change

- [x] New skill / agent / hook

## Checklist

- [x] I have read the [Contributing Guide](CONTRIBUTING.md)
- [x] Branch follows naming convention (`feat/`, `fix/`, `refactor/`, etc.)
- [x] Commits use [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] `python3 scripts/validate.py` passes
- [ ] `python3 scripts/audit_skills.py --ci` passes (0 HIGH)
- [ ] `bats tests/` passes
- [x] New code has no external dependencies (stdlib only)
- [x] No secrets, tokens, or API keys in the code

## Notes for Maintainer

- `disable-model-invocation: true` — task skill, no LLM calls
- `allowed-tools: Read, Grep, Glob` — read-only, never modifies files
- Two modes: `developer` (default, categories 1/3/4/7/8, low false-positive) and `compliance` (all 8 categories for audit sweeps)
- Supports `.hipaaignore` for suppressing confirmed false positives and `.hipaa-config` for BAA vendor tracking