### PR TITLE
test(dsh): give process-tree teardown a budget a loaded runner can meet

### DIFF
--- a/tests/test_dsh.bats
+++ b/tests/test_dsh.bats
@@ -818,7 +818,7 @@ PY
     cat > "$TEST_DSH_HOME/fake-control.json" <<'JSON'
 {
   "spawn_delayed_descendant_tree_before":"add:@softspark/dsh-codex",
-  "descendant_delay_seconds":0.4,
+  "descendant_delay_seconds":2.0,
   "descendant_host_sleep_seconds":5,
   "descendant_parent_sleep_seconds":5
 }
@@ -834,7 +834,15 @@ PY
 
     [ "$status" -ne 0 ]
     [[ "$output" == *"timed out after 0.2s"* ]] || false
-    sleep 0.7
+    # The descendant writes its marker descendant_delay_seconds after spawn and
+    # the interrupt fires at 0.2s, so teardown has that difference to kill it.
+    # At 0.4s the budget was 200ms, which a loaded macOS runner misses; the test
+    # then failed for runner load rather than for broken teardown.
+    #
+    # This wait MUST stay longer than descendant_delay_seconds. Raise one without
+    # the other and a descendant that was never killed simply has not written
+    # yet, so the assertion below passes while proving nothing.
+    sleep 3
     [ ! -e "$TEST_DSH_HOME/late-descendant-marker.txt" ] || false
     [ ! -e "$TEST_DSH_HOME/profiles/web/late-descendant-profile-write.txt" ] || false
     [ ! -e "$TEST_DSH_HOME/profiles/web/package.json" ]
@@ -847,7 +855,7 @@ PY
     cat > "$TEST_DSH_HOME/fake-control.json" <<'JSON'
 {
   "spawn_delayed_descendant_tree_before":"add:@softspark/dsh-codex",
-  "descendant_delay_seconds":0.4,
+  "descendant_delay_seconds":2.0,
   "descendant_host_sleep_seconds":5,
   "descendant_parent_sleep_seconds":5
 }
@@ -885,7 +893,15 @@ PY
 
     [ "$status" -ne 0 ]
     [[ "$output" == *"interrupted"* ]] || false
-    sleep 0.7
+    # The descendant writes its marker descendant_delay_seconds after spawn and
+    # the interrupt fires at 0.2s, so teardown has that difference to kill it.
+    # At 0.4s the budget was 200ms, which a loaded macOS runner misses; the test
+    # then failed for runner load rather than for broken teardown.
+    #
+    # This wait MUST stay longer than descendant_delay_seconds. Raise one without
+    # the other and a descendant that was never killed simply has not written
+    # yet, so the assertion below passes while proving nothing.
+    sleep 3
     [ ! -e "$TEST_DSH_HOME/late-descendant-marker.txt" ] || false
     [ ! -e "$TEST_DSH_HOME/profiles/web/late-descendant-profile-write.txt" ] || false
     [ ! -e "$TEST_DSH_HOME/profiles/web/package.json" ]
@@ -898,7 +914,7 @@ PY
     cat > "$TEST_DSH_HOME/fake-control.json" <<'JSON'
 {
   "spawn_delayed_descendant_tree_before":"add:@softspark/dsh-codex",
-  "descendant_delay_seconds":0.4,
+  "descendant_delay_seconds":2.0,
   "descendant_host_sleep_seconds":5,
   "descendant_parent_sleep_seconds":5
 }
@@ -961,7 +977,15 @@ PY
     [[ "$output" == *"interrupted"* ]] || false
     [[ "$output" == *"teardown-retried-sigint"* ]] || false
     [[ "$output" != *"Traceback"* ]] || false
-    sleep 0.7
+    # The descendant writes its marker descendant_delay_seconds after spawn and
+    # the interrupt fires at 0.2s, so teardown has that difference to kill it.
+    # At 0.4s the budget was 200ms, which a loaded macOS runner misses; the test
+    # then failed for runner load rather than for broken teardown.
+    #
+    # This wait MUST stay longer than descendant_delay_seconds. Raise one without
+    # the other and a descendant that was never killed simply has not written
+    # yet, so the assertion below passes while proving nothing.
+    sleep 3
     [ ! -e "$TEST_DSH_HOME/late-descendant-marker.txt" ] || false
     [ ! -e "$TEST_DSH_HOME/profiles/web/late-descendant-profile-write.txt" ] || false
     [ ! -e "$TEST_DSH_HOME/profiles/web/package.json" ]


### PR DESCRIPTION
The three delayed-descendant tests interrupt at 0.2s and let the descendant write its marker at 0.4s, so teardown had **200ms** to kill the tree. Enough on a developer machine; not enough on a loaded macOS runner, where the tests failed for runner load rather than for broken teardown.

This suite has been red across several releases with a *different* test each time, on both platforms — v4.30.2 hit test 600 on macOS, v4.30.1 hit 640/647/1547 on ubuntu, and #15 hit 592/593 on macOS. All three pass locally on macOS.

- `descendant_delay_seconds` 0.4 → 2.0, making the budget 1.8s
- the post-run wait 0.7 → 3 **in the same change**, because raising the delay alone would mean a descendant that was never killed simply has not written yet — the assertion would pass while proving nothing. The comment says so, so the two cannot drift apart later.

**Verified by mutation:** at `2.0` all three pass; at `0.01` all three fail. The assertion still fires.