### PR TITLE
docs(validation): capture frontend and backend contract parity

### DIFF
--- a/app/skills/api-patterns/SKILL.md
+++ b/app/skills/api-patterns/SKILL.md
@@ -94,6 +94,10 @@ the original cause, preserve public codes and JSON types, and distinguish an
 unknown operation outcome from a confirmed refusal. Do not turn arbitrary
 server failures into invalid-input responses.
 
+When adding client-side validation, read the
+[validation contract gotchas](../security-patterns/reference/input-validation.md#validation-contract-gotchas).
+Use one authoritative rule source and prove parity at the request boundary.
+
 ---
 
 ## FastAPI Implementation
@@ -168,7 +172,7 @@ In OpenAPI, pair `enum` with the value meanings in the description (or `x-enum-d
 
 ### Encode cross-field dependencies in the description
 
-If a field is only valid given another, say so where the dependent field is defined — schemas cannot express "required when":
+Document cross-field requirements where the dependent field is defined and encode them in the supported schema dialect. JSON Schema supports conditional requirements with `dependentRequired` or `if`/`then`; application state and opaque-token provenance still require prose and runtime checks. See [conditional schema validation](https://json-schema.org/understanding-json-schema/reference/conditionals).
 
 ```python
 cursor: str | None = Field(
@@ -394,7 +398,7 @@ Accept: application/vnd.myapi.v1+json
 ## Hard Rules
 
 - **MUST** version the API from day one (URL path or Accept header) — unversioned APIs break clients on every change
-- **MUST** validate every input at the API boundary, not inside business logic
+- **MUST** validate input type, format and size at the API boundary; enforce state-dependent domain invariants in business logic as well
 - **MUST** use PUT for full replacement and PATCH for partial update — confusing the two causes silent data loss
 - **NEVER** return unbounded list responses — pagination (offset or cursor) is mandatory
 - **NEVER** expose private implementation details in ordinary API errors, including 4xx and background-job error fields; preserve the host's public error representation
@@ -417,7 +421,7 @@ Accept: application/vnd.myapi.v1+json
 ## Gotchas
 
 - CDN and load-balancer caches key on the full URL by default. If you version via both URL path and `Accept` header (e.g., `/api/v1/...` + `Accept: application/vnd.myapi.v2+json`), the edge returns the wrong payload for non-path versioning. Pick one versioning axis and stick to it.
-- OpenAPI `additionalProperties: false` is **not** enforced by most JSON Schema validators unless you explicitly enable strict mode (`ajv({strict: true})`, Pydantic `Config.extra = "forbid"`). An API marked "strict" in the spec silently accepts unknown fields.
+- A published OpenAPI schema does not prove request enforcement. Ajv enforces `additionalProperties: false` when that schema is executed; its strict mode checks schema correctness and does not change validation results. Verify that the request boundary runs the intended schema and test unknown fields. See [Ajv strict mode](https://ajv.js.org/strict-mode.html) and [additionalProperties](https://ajv.js.org/json-schema.html#additionalproperties).
 - `Idempotency-Key` only works if the server persists the mapping from key to response — purely in-memory implementations forget it on restart. Back it with Redis or the primary DB.
 - HTTP methods are **case-sensitive** per RFC 7230 (all uppercase); some clients and proxies normalize, some don't. A `post` method reaches the server as-is through some edge proxies and hits a 405 instead of the POST route.
 - Give rate-limited callers a meaningful `Retry-After`. For 503, include it when the server can provide a credible retry window; do not invent an outage duration. A retry header does not prove that repeating a write is safe.

--- a/app/skills/review/SKILL.md
+++ b/app/skills/review/SKILL.md
@@ -125,6 +125,8 @@ After all reviewers complete:
 - [ ] Backward compatibility preserved (no silent breaking changes)
 - [ ] API versioning updated if contract changed
 - [ ] Schema validation on request/response
+- [ ] Client validation uses the authoritative input contract, including operation groups/defaults, finite bounds, nested paths and documented Unicode units; review the [validation gotchas](../security-patterns/reference/input-validation.md#validation-contract-gotchas)
+- [ ] Shared backend/client fixtures and generation drift checks cover changed rules; unsupported/server-only checks are explicit, and local refusals do not masquerade as HTTP responses
 - [ ] Error responses follow project convention
 - [ ] Statuses and messages distinguish input/state refusals from infrastructure failures; original causes remain available in authorized diagnostics
 - [ ] Error filtering preserves machine codes, field paths, JSON object/list types, locale and recovery headers; background-job error fields are covered too

--- a/app/skills/security-patterns/SKILL.md
+++ b/app/skills/security-patterns/SKILL.md
@@ -129,13 +129,13 @@ For authentication patterns (JWT, passwords, token strategy), see [reference/aut
 
 For authorization patterns (RBAC, ABAC), see [reference/authorization.md](reference/authorization.md).
 
-For input validation patterns (SQL injection, XSS, Pydantic), see [reference/input-validation.md](reference/input-validation.md).
+For input validation, client/backend contract parity, finite bounds and Unicode gotchas, see [reference/input-validation.md](reference/input-validation.md).
 
 For OAuth2 flows, CSRF protection, and audit logging, see [reference/oauth-csrf-audit.md](reference/oauth-csrf-audit.md).
 
 ## Rules
 
-- **MUST** validate all input at the trust boundary, not inside business logic — deep validation allows bad data to spread before rejection
+- **MUST** validate input type, format and size at the trust boundary; domain logic must also enforce state-dependent invariants before side effects
 - **MUST** use parameterized queries (prepared statements) for every SQL interaction — string concatenation is SQL injection
 - **NEVER** store secrets (API keys, tokens, passwords) in code, config files, or git history — use the platform's secret manager
 - **NEVER** log passwords, tokens, PII, or PHI — even at debug level. Logs reach aggregation systems, backups, and disk snapshots.

--- a/app/skills/security-patterns/reference/input-validation.md
+++ b/app/skills/security-patterns/reference/input-validation.md
@@ -2,13 +2,80 @@
 
 ## Validation Rules
 ```python
-from pydantic import BaseModel, EmailStr, constr
+from pydantic import BaseModel, EmailStr, Field, constr
 
 class UserInput(BaseModel):
     email: EmailStr
     username: constr(min_length=3, max_length=20, pattern=r'^[a-zA-Z0-9_]+$')
     age: int = Field(ge=0, le=150)
 ```
+
+## Validation contract gotchas
+
+These traps came from repeated corrections during a DTO-to-client validation
+rollout. Apply them when a client mirrors server rules; they do not require a
+new generator for every small form.
+
+- **Two validators can still be two conflicting policies.** Derive portable
+  client checks from the server's authoritative schema or resolved metadata.
+  A shared schema is also valid when the backend actually enforces it. Bind
+  field feedback and serialized-payload preflight to that same contract.
+  Backend enforcement remains mandatory, including when client code is bypassed.
+- **The entity may never be validated.** Trace the operation's real input object.
+  In API Platform, an input DTO can be validated before mapping to an entity.
+  Validation groups select constraints; denormalization groups select writable
+  fields. Output-only constraints add no protection to the request path.
+- **PATCH does not make every property optional.** An update hydrated from
+  existing state and a newly constructed input DTO have different missing-field
+  semantics. Preserve actual defaults and distinguish omitted keys, null and
+  empty values. Resolve this per operation, not from the HTTP method alone.
+- **A constraint name is not a finite bound.** Length(min), Count(min),
+  All(Email) and an unbounded regex do not cap input size. Check actual maximum
+  values, collection size, item shape/type and nested validation separately.
+  In Symfony, retain All/Collection/Valid and sequential evaluation semantics.
+  Bound body size and violation output too; stop expensive item validation
+  after an oversized list is refused.
+- **A field name does not identify its storage or wire format.** Read the
+  mapper/processor and owning storage before choosing limits. An Id field can
+  accept an IRI; a timestamp ceiling does not validate a real date. Feature
+  limits and established domain error codes can be stricter or more specific
+  than a generic ceiling. Do not replace them accidentally in a bulk pass.
+- **Unicode length has several units.** Specify bytes, code units, codepoints
+  or grapheme clusters and the normalization order. Test decomposed accents,
+  non-BMP characters, joined emoji and IME composition. A client must not
+  silently truncate a value the server accepts; preserve input when showing an
+  error. Do not normalize passwords or apply identifier alphabet rules to
+  names without a documented product policy.
+- **Rule names hide runtime options.** Email modes, URL schemes, numeric
+  coercion, regex dialects and conditional validation can differ across
+  languages. Export supported options explicitly. Conditional rules are
+  audited data, never arbitrary server expressions evaluated in the client.
+- **Some checks depend on server state or libraries.** Keep authorization,
+  availability, uniqueness and domain invariants on the server. If a portable
+  equivalent is unavailable, record the exact operation/field/rule and reason
+  in reviewed policy. Newly unsupported rules must surface as a failed
+  generation/check step, not become an always-valid adapter. Bodyless routes
+  and exclusions are separate measurements, not evidence of client coverage.
+- **A local refusal is not an HTTP response.** Use a distinct local error type,
+  preserve field paths and rule codes, and show localized field feedback.
+  Do not invent an HTTP status or trigger token refresh/network retry for a
+  request that was never sent. Server refusals remain authoritative; keep
+  local/server error state distinguishable and test correction/resubmission.
+- **Generation proves synchronization, not semantic equivalence.** Run shared
+  accepted/rejected fixtures through the real backend validator and client
+  evaluator, including both conditional branches and nested error paths.
+  Check deterministic generation and reviewed exclusions in CI. A snapshot
+  of the exporter tested against itself does not prove parity. HTTP tests
+  must also exercise deserialization and rejected-write persistence behavior.
+
+Input validation does not replace parameterized queries or context-appropriate
+output encoding. The backend may still reject a client-valid request because
+state changed after local validation.
+
+For regression selection, see
+[testing patterns](../../testing-patterns/SKILL.md#validation-contract-regressions).
+For HTTP failure semantics, see
+[error contracts](../../api-patterns/reference/error-contracts.md).
 
 ## SQL Injection Prevention
 ```python

--- a/app/skills/testing-patterns/SKILL.md
+++ b/app/skills/testing-patterns/SKILL.md
@@ -53,6 +53,23 @@ tests/
 
 ---
 
+## Validation contract regressions
+
+Mirrored validators can agree on a generated snapshot while disagreeing on real
+inputs. Execute the same accepted/rejected fixtures against the real backend
+validator and the client evaluator. Include N/N+1 boundaries, collection/item
+limits, omitted/null/empty/default values, nested paths, conditional branches,
+hydrated updates versus fresh DTOs, Unicode units and previously valid inputs.
+
+Test the actual HTTP path for malformed input and unchanged persisted state
+after a pre-write refusal. Test zero transport calls for a local refusal,
+normal transport for a valid payload, and field correction/resubmission.
+Run deterministic-generation and reviewed-exclusion checks separately from
+behavioral parity. A schema/rule count is inventory, not assertion coverage.
+
+See the [validation contract gotchas](../security-patterns/reference/input-validation.md#validation-contract-gotchas)
+for operation semantics and runtime mismatches.
+
 ## Language-Specific References
 
 | Language | Reference | Key Topics |


### PR DESCRIPTION
## Summary

Document how frontend validation mirrors the backend contract without creating a conflicting input policy. The existing API, security, review and testing skills now cover operation-specific DTO semantics, finite bounds, Unicode, explicit server-only checks and shared parity fixtures.

Correct the JSON Schema conditional-validation and Ajv strict-mode guidance, retain domain validation alongside boundary checks, and add the missing Pydantic Field import. Agent and skill frontmatter, permissions and models are unchanged.

## Test plan

- [x] `npm run generate:all`, no additional tracked artifact changes
- [x] `python3 scripts/validate.py --strict`, 0 errors and warnings
- [x] `python3 scripts/evaluate_skills.py`, 114/114
- [x] `python3 scripts/audit_skills.py --ci`, HIGH 0 and WARN 0
- [x] ShellCheck hooks and Python syntax
- [x] `npm test`, 1978/1978 with no skips
- [x] Pre-commit scan, no secrets or warnings

Local macOS tests use the matching Node/npm 22 installation, GNU coreutils and `TMPDIR=/private/tmp`. The default BSD temporary-path spelling caused ten DSH recovery assertions to fail on unchanged HEAD; those ten cases and the complete suite pass in the corrected environment.
