### PR TITLE
chore: release v4.32.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Versioning follows [Semantic Versioning](https://semver.org/).
   and frontend rule source, operation-specific DTO groups/defaults, finite
   collection bounds, Unicode units, explicit server-only checks and parity
   fixtures. Local validation failures remain distinct from HTTP responses.
+  Cross-skill references resolve through the installed catalog so namespaced
+  adapters, including GitHub Copilot, can find the same guidance.
 - **API error contracts:** Preserve the host's error representation and
   distinguish domain refusals from technical failures. Cover actionable
   messages, JSON types, background-job failures, unknown outcomes and safe

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,39 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
-## Unreleased
+## v4.32.4 - Validation parity and API error contracts (2026-09-06)
 
 ### Changed
 
-- API guidance preserves the host's existing error representation and separates
-  supported domain refusals from technical failures. A focused reference covers
-  actionable messages, JSON type preservation, background-job errors and safe
-  retries when an operation outcome is unknown.
-- Common security/testing rules and the review checklist cover error contracts
-  and shared-database test isolation. The FastAPI example preserves exception
-  provenance and catches a specific request-level refusal instead of exposing
-  arbitrary `ValueError` text.
+- **Validation contracts:** Add practical guidance to `/api-patterns`,
+  `/security-patterns`, `/review` and `/testing-patterns` for a shared backend
+  and frontend rule source, operation-specific DTO groups/defaults, finite
+  collection bounds, Unicode units, explicit server-only checks and parity
+  fixtures. Local validation failures remain distinct from HTTP responses.
+- **API error contracts:** Preserve the host's error representation and
+  distinguish domain refusals from technical failures. Cover actionable
+  messages, JSON types, background-job failures, unknown outcomes and safe
+  retries. Common security/testing rules retain shared-database test isolation.
+
+### Fixed
+
+- **Schema guidance:** Correct JSON Schema conditional requirements and Ajv
+  strict-mode semantics, retain domain checks alongside boundary validation,
+  and import `Field` in the Pydantic example. The FastAPI example catches a
+  specific request refusal while preserving its exception cause.
+- **Release verification:** Compare inventories with the current artifact,
+  run installation smoke in a disposable environment, and fail when an
+  expected generated JSON file is missing. Preserve the operator's install
+  and authentication state during candidate and published-package checks.
+- **Package metadata:** Refresh skill and hook inventory descriptions.
+
+### Release checks
+
+- **Ecosystem:** Refresh documentation hashes and local CLI version probes;
+  the review found no heading or capability-marker changes and changes no
+  generators, runtime integration paths or permission declarations.
+- **Skill body budget:** Keep the existing 18,000-byte warning threshold;
+  the largest body remains 17,197 bytes, so the ratchet cannot tighten yet.
 
 ## v4.32.3 — Search-first stops firing on things nobody asked (2026-09-04)
 

--- a/README.md
+++ b/README.md
@@ -8,28 +8,22 @@
 [![Agents](https://img.shields.io/badge/agents-44-blue)](app/agents/)
 [![Tests](https://img.shields.io/badge/tests-1978%20passing-success)](tests/)
 
-## What's New in v4.32.3
+## What's New in v4.32.4
 
-**v4.32.3** stops search-first enforcement firing on things nobody asked:
+**v4.32.4** documents validation parity and reliable API error handling:
 
-- **A background task finishing no longer blocks `Stop`.** The search-required
-  flag was set on any stdin over 30 characters, and the harness delivers
-  background-task notifications, CI events and replayed slash-command output
-  on the same channel as a prompt. Event envelopes no longer set it.
-- **A pasted credential no longer becomes a search query.** A 43-character API
-  key on its own line cleared the length gate, and the block message names the
-  prompt as the thing to search for — so the enforcement path asked for a live
-  secret to be sent to a retrieval service. Single-token prompts no longer set
-  the flag.
-- Nothing that was enforced before stops being enforced: a genuine one-word
-  prompt is under the length gate anyway, and prose that merely mentions a task
-  notification still sets the flag. That case is now a test.
-- Still in this train: exports land in the directory you ran the command in
-  (v4.32.2); `plugin remove` leaves nothing behind, every skill script answers
-  `--help` (v4.32.1); path-scoped common rules, project-scoped language skills,
-  `doctor` context-budget and permission checks, one strict frontmatter parser,
-  `git-team` for `--profile strict` (v4.32.0). Test count: 1974 -> 1978 bats +
-  348 pytest.
+- **One validation contract for frontend and backend.** Existing skills cover
+  DTO groups/defaults, nested collections, Unicode, explicit server-only checks
+  and shared regression fixtures, with backend enforcement kept authoritative.
+- **Errors preserve the API contract.** Guidance separates local refusals,
+  domain conflicts and technical failures, retaining field paths, machine
+  codes and safe recovery when a write outcome is uncertain.
+- **Schema examples match validator behavior.** Correct JSON Schema
+  conditional requirements and Ajv strict-mode guidance; keep state-dependent
+  domain checks alongside validation at the request boundary.
+- **Release smoke tests verify the installed artifact.** Procedures use
+  disposable environments, current inventories and assertions for missing
+  generated files, without modifying the operator's live installation.
 
 See [CHANGELOG.md](CHANGELOG.md) for full history.
 
@@ -211,7 +205,7 @@ ai-toolkit/
 │   ├── agents/          # 44 agent definitions
 │   ├── skills/          # 114 skills (task / hybrid / knowledge)
 │   ├── rules/           # Source rules synced into Claude/editor rule files
-│   ├── hooks/           # Hook scripts (29 entries, 14 lifecycle events)
+│   ├── hooks/           # Hook scripts (28 entries, 14 lifecycle events)
 │   ├── claude-app/      # Generated Chat/Cowork plugin rules, hooks, instructions
 │   ├── plugins/         # 2 experimental plugin packs (opt-in)
 │   ├── output-styles/   # System prompt output style overrides

--- a/app/.claude-plugin/plugin.json
+++ b/app/.claude-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "ai-toolkit",
   "displayName": "AI Toolkit",
   "description": "Professional-grade engineering skills, agents, rules, and lifecycle guardrails for Claude Code, Claude Chat, and Cowork.",
-  "version": "4.32.3",
+  "version": "4.32.4",
   "author": {
     "name": "SoftSpark",
     "url": "https://github.com/softspark"

--- a/app/ARCHITECTURE.md
+++ b/app/ARCHITECTURE.md
@@ -8,7 +8,7 @@ Universal multi-agent system for software development. Works across all reposito
 |-----------|-------|
 | Agents | See agents catalog |
 | Skills | See skills catalog |
-| Hooks | 14 events / 29 entries (SessionStart ×2, Notification ×1, PreToolUse ×5, UserPromptSubmit ×2, PostToolUse ×6, Stop ×4, TaskCompleted ×1, TeammateIdle ×1, SubagentStart ×1, SubagentStop ×1, PreCompact ×2, SessionEnd ×1, InstructionsLoaded ×1, ConfigChange ×1) plus statusLine |
+| Hooks | 14 events / 28 entries (SessionStart ×2, Notification ×1, PreToolUse ×5, UserPromptSubmit ×2, PostToolUse ×5, Stop ×4, TaskCompleted ×1, TeammateIdle ×1, SubagentStart ×1, SubagentStop ×1, PreCompact ×2, SessionEnd ×1, InstructionsLoaded ×1, ConfigChange ×1) plus statusLine |
 
 ---
 

--- a/app/skills/api-patterns/SKILL.md
+++ b/app/skills/api-patterns/SKILL.md
@@ -94,6 +94,10 @@ the original cause, preserve public codes and JSON types, and distinguish an
 unknown operation outcome from a confirmed refusal. Do not turn arbitrary
 server failures into invalid-input responses.
 
+When adding client-side validation, read the
+[validation contract gotchas](../security-patterns/reference/input-validation.md#validation-contract-gotchas).
+Use one authoritative rule source and prove parity at the request boundary.
+
 ---
 
 ## FastAPI Implementation
@@ -168,7 +172,7 @@ In OpenAPI, pair `enum` with the value meanings in the description (or `x-enum-d
 
 ### Encode cross-field dependencies in the description
 
-If a field is only valid given another, say so where the dependent field is defined — schemas cannot express "required when":
+Document cross-field requirements where the dependent field is defined and encode them in the supported schema dialect. JSON Schema supports conditional requirements with `dependentRequired` or `if`/`then`; application state and opaque-token provenance still require prose and runtime checks. See [conditional schema validation](https://json-schema.org/understanding-json-schema/reference/conditionals).
 
 ```python
 cursor: str | None = Field(
@@ -394,7 +398,7 @@ Accept: application/vnd.myapi.v1+json
 ## Hard Rules
 
 - **MUST** version the API from day one (URL path or Accept header) — unversioned APIs break clients on every change
-- **MUST** validate every input at the API boundary, not inside business logic
+- **MUST** validate input type, format and size at the API boundary; enforce state-dependent domain invariants in business logic as well
 - **MUST** use PUT for full replacement and PATCH for partial update — confusing the two causes silent data loss
 - **NEVER** return unbounded list responses — pagination (offset or cursor) is mandatory
 - **NEVER** expose private implementation details in ordinary API errors, including 4xx and background-job error fields; preserve the host's public error representation
@@ -417,7 +421,7 @@ Accept: application/vnd.myapi.v1+json
 ## Gotchas
 
 - CDN and load-balancer caches key on the full URL by default. If you version via both URL path and `Accept` header (e.g., `/api/v1/...` + `Accept: application/vnd.myapi.v2+json`), the edge returns the wrong payload for non-path versioning. Pick one versioning axis and stick to it.
-- OpenAPI `additionalProperties: false` is **not** enforced by most JSON Schema validators unless you explicitly enable strict mode (`ajv({strict: true})`, Pydantic `Config.extra = "forbid"`). An API marked "strict" in the spec silently accepts unknown fields.
+- A published OpenAPI schema does not prove request enforcement. Ajv enforces `additionalProperties: false` when that schema is executed; its strict mode checks schema correctness and does not change validation results. Verify that the request boundary runs the intended schema and test unknown fields. See [Ajv strict mode](https://ajv.js.org/strict-mode.html) and [additionalProperties](https://ajv.js.org/json-schema.html#additionalproperties).
 - `Idempotency-Key` only works if the server persists the mapping from key to response — purely in-memory implementations forget it on restart. Back it with Redis or the primary DB.
 - HTTP methods are **case-sensitive** per RFC 7230 (all uppercase); some clients and proxies normalize, some don't. A `post` method reaches the server as-is through some edge proxies and hits a 405 instead of the POST route.
 - Give rate-limited callers a meaningful `Retry-After`. For 503, include it when the server can provide a credible retry window; do not invent an outage duration. A retry header does not prove that repeating a write is safe.

--- a/app/skills/api-patterns/SKILL.md
+++ b/app/skills/api-patterns/SKILL.md
@@ -94,8 +94,9 @@ the original cause, preserve public codes and JSON types, and distinguish an
 unknown operation outcome from a confirmed refusal. Do not turn arbitrary
 server failures into invalid-input responses.
 
-When adding client-side validation, read the
-[validation contract gotchas](../security-patterns/reference/input-validation.md#validation-contract-gotchas).
+When adding client-side validation, read `reference/input-validation.md` from
+the installed `security-patterns` skill. Resolve that skill through the current
+client's catalog, since adapters may namespace skill directory names.
 Use one authoritative rule source and prove parity at the request boundary.
 
 ---

--- a/app/skills/review/SKILL.md
+++ b/app/skills/review/SKILL.md
@@ -125,6 +125,8 @@ After all reviewers complete:
 - [ ] Backward compatibility preserved (no silent breaking changes)
 - [ ] API versioning updated if contract changed
 - [ ] Schema validation on request/response
+- [ ] Client validation uses the authoritative input contract, including operation groups/defaults, finite bounds, nested paths and documented Unicode units; review the [validation gotchas](../security-patterns/reference/input-validation.md#validation-contract-gotchas)
+- [ ] Shared backend/client fixtures and generation drift checks cover changed rules; unsupported/server-only checks are explicit, and local refusals do not masquerade as HTTP responses
 - [ ] Error responses follow project convention
 - [ ] Statuses and messages distinguish input/state refusals from infrastructure failures; original causes remain available in authorized diagnostics
 - [ ] Error filtering preserves machine codes, field paths, JSON object/list types, locale and recovery headers; background-job error fields are covered too

--- a/app/skills/review/SKILL.md
+++ b/app/skills/review/SKILL.md
@@ -125,7 +125,7 @@ After all reviewers complete:
 - [ ] Backward compatibility preserved (no silent breaking changes)
 - [ ] API versioning updated if contract changed
 - [ ] Schema validation on request/response
-- [ ] Client validation uses the authoritative input contract, including operation groups/defaults, finite bounds, nested paths and documented Unicode units; review the [validation gotchas](../security-patterns/reference/input-validation.md#validation-contract-gotchas)
+- [ ] Client validation uses the authoritative input contract, including operation groups/defaults, finite bounds, nested paths and documented Unicode units; read `reference/input-validation.md` from the `security-patterns` skill located through the current client's installed catalog
 - [ ] Shared backend/client fixtures and generation drift checks cover changed rules; unsupported/server-only checks are explicit, and local refusals do not masquerade as HTTP responses
 - [ ] Error responses follow project convention
 - [ ] Statuses and messages distinguish input/state refusals from infrastructure failures; original causes remain available in authorized diagnostics

--- a/app/skills/security-patterns/SKILL.md
+++ b/app/skills/security-patterns/SKILL.md
@@ -129,13 +129,13 @@ For authentication patterns (JWT, passwords, token strategy), see [reference/aut
 
 For authorization patterns (RBAC, ABAC), see [reference/authorization.md](reference/authorization.md).
 
-For input validation patterns (SQL injection, XSS, Pydantic), see [reference/input-validation.md](reference/input-validation.md).
+For input validation, client/backend contract parity, finite bounds and Unicode gotchas, see [reference/input-validation.md](reference/input-validation.md).
 
 For OAuth2 flows, CSRF protection, and audit logging, see [reference/oauth-csrf-audit.md](reference/oauth-csrf-audit.md).
 
 ## Rules
 
-- **MUST** validate all input at the trust boundary, not inside business logic — deep validation allows bad data to spread before rejection
+- **MUST** validate input type, format and size at the trust boundary; domain logic must also enforce state-dependent invariants before side effects
 - **MUST** use parameterized queries (prepared statements) for every SQL interaction — string concatenation is SQL injection
 - **NEVER** store secrets (API keys, tokens, passwords) in code, config files, or git history — use the platform's secret manager
 - **NEVER** log passwords, tokens, PII, or PHI — even at debug level. Logs reach aggregation systems, backups, and disk snapshots.

--- a/app/skills/security-patterns/reference/input-validation.md
+++ b/app/skills/security-patterns/reference/input-validation.md
@@ -72,10 +72,11 @@ Input validation does not replace parameterized queries or context-appropriate
 output encoding. The backend may still reject a client-valid request because
 state changed after local validation.
 
-For regression selection, see
-[testing patterns](../../testing-patterns/SKILL.md#validation-contract-regressions).
-For HTTP failure semantics, see
-[error contracts](../../api-patterns/reference/error-contracts.md).
+For regression selection, use the "Validation contract regressions" section
+of the installed `testing-patterns` skill. For HTTP failure semantics, read
+`reference/error-contracts.md` from the installed `api-patterns` skill.
+Locate these skills through the current client's catalog because adapters may
+namespace their directory names.
 
 ## SQL Injection Prevention
 ```python

--- a/app/skills/security-patterns/reference/input-validation.md
+++ b/app/skills/security-patterns/reference/input-validation.md
@@ -2,13 +2,80 @@
 
 ## Validation Rules
 ```python
-from pydantic import BaseModel, EmailStr, constr
+from pydantic import BaseModel, EmailStr, Field, constr
 
 class UserInput(BaseModel):
     email: EmailStr
     username: constr(min_length=3, max_length=20, pattern=r'^[a-zA-Z0-9_]+$')
     age: int = Field(ge=0, le=150)
 ```
+
+## Validation contract gotchas
+
+These traps came from repeated corrections during a DTO-to-client validation
+rollout. Apply them when a client mirrors server rules; they do not require a
+new generator for every small form.
+
+- **Two validators can still be two conflicting policies.** Derive portable
+  client checks from the server's authoritative schema or resolved metadata.
+  A shared schema is also valid when the backend actually enforces it. Bind
+  field feedback and serialized-payload preflight to that same contract.
+  Backend enforcement remains mandatory, including when client code is bypassed.
+- **The entity may never be validated.** Trace the operation's real input object.
+  In API Platform, an input DTO can be validated before mapping to an entity.
+  Validation groups select constraints; denormalization groups select writable
+  fields. Output-only constraints add no protection to the request path.
+- **PATCH does not make every property optional.** An update hydrated from
+  existing state and a newly constructed input DTO have different missing-field
+  semantics. Preserve actual defaults and distinguish omitted keys, null and
+  empty values. Resolve this per operation, not from the HTTP method alone.
+- **A constraint name is not a finite bound.** Length(min), Count(min),
+  All(Email) and an unbounded regex do not cap input size. Check actual maximum
+  values, collection size, item shape/type and nested validation separately.
+  In Symfony, retain All/Collection/Valid and sequential evaluation semantics.
+  Bound body size and violation output too; stop expensive item validation
+  after an oversized list is refused.
+- **A field name does not identify its storage or wire format.** Read the
+  mapper/processor and owning storage before choosing limits. An Id field can
+  accept an IRI; a timestamp ceiling does not validate a real date. Feature
+  limits and established domain error codes can be stricter or more specific
+  than a generic ceiling. Do not replace them accidentally in a bulk pass.
+- **Unicode length has several units.** Specify bytes, code units, codepoints
+  or grapheme clusters and the normalization order. Test decomposed accents,
+  non-BMP characters, joined emoji and IME composition. A client must not
+  silently truncate a value the server accepts; preserve input when showing an
+  error. Do not normalize passwords or apply identifier alphabet rules to
+  names without a documented product policy.
+- **Rule names hide runtime options.** Email modes, URL schemes, numeric
+  coercion, regex dialects and conditional validation can differ across
+  languages. Export supported options explicitly. Conditional rules are
+  audited data, never arbitrary server expressions evaluated in the client.
+- **Some checks depend on server state or libraries.** Keep authorization,
+  availability, uniqueness and domain invariants on the server. If a portable
+  equivalent is unavailable, record the exact operation/field/rule and reason
+  in reviewed policy. Newly unsupported rules must surface as a failed
+  generation/check step, not become an always-valid adapter. Bodyless routes
+  and exclusions are separate measurements, not evidence of client coverage.
+- **A local refusal is not an HTTP response.** Use a distinct local error type,
+  preserve field paths and rule codes, and show localized field feedback.
+  Do not invent an HTTP status or trigger token refresh/network retry for a
+  request that was never sent. Server refusals remain authoritative; keep
+  local/server error state distinguishable and test correction/resubmission.
+- **Generation proves synchronization, not semantic equivalence.** Run shared
+  accepted/rejected fixtures through the real backend validator and client
+  evaluator, including both conditional branches and nested error paths.
+  Check deterministic generation and reviewed exclusions in CI. A snapshot
+  of the exporter tested against itself does not prove parity. HTTP tests
+  must also exercise deserialization and rejected-write persistence behavior.
+
+Input validation does not replace parameterized queries or context-appropriate
+output encoding. The backend may still reject a client-valid request because
+state changed after local validation.
+
+For regression selection, see
+[testing patterns](../../testing-patterns/SKILL.md#validation-contract-regressions).
+For HTTP failure semantics, see
+[error contracts](../../api-patterns/reference/error-contracts.md).
 
 ## SQL Injection Prevention
 ```python

--- a/app/skills/testing-patterns/SKILL.md
+++ b/app/skills/testing-patterns/SKILL.md
@@ -53,6 +53,23 @@ tests/
 
 ---
 
+## Validation contract regressions
+
+Mirrored validators can agree on a generated snapshot while disagreeing on real
+inputs. Execute the same accepted/rejected fixtures against the real backend
+validator and the client evaluator. Include N/N+1 boundaries, collection/item
+limits, omitted/null/empty/default values, nested paths, conditional branches,
+hydrated updates versus fresh DTOs, Unicode units and previously valid inputs.
+
+Test the actual HTTP path for malformed input and unchanged persisted state
+after a pre-write refusal. Test zero transport calls for a local refusal,
+normal transport for a valid payload, and field correction/resubmission.
+Run deterministic-generation and reviewed-exclusion checks separately from
+behavioral parity. A schema/rule count is inventory, not assertion coverage.
+
+See the [validation contract gotchas](../security-patterns/reference/input-validation.md#validation-contract-gotchas)
+for operation semantics and runtime mismatches.
+
 ## Language-Specific References
 
 | Language | Reference | Key Topics |

--- a/app/skills/testing-patterns/SKILL.md
+++ b/app/skills/testing-patterns/SKILL.md
@@ -67,8 +67,10 @@ normal transport for a valid payload, and field correction/resubmission.
 Run deterministic-generation and reviewed-exclusion checks separately from
 behavioral parity. A schema/rule count is inventory, not assertion coverage.
 
-See the [validation contract gotchas](../security-patterns/reference/input-validation.md#validation-contract-gotchas)
-for operation semantics and runtime mismatches.
+For operation semantics and runtime mismatches, read
+`reference/input-validation.md` from the installed `security-patterns` skill.
+Resolve the skill through the current client's catalog; directory names may
+carry an adapter-specific prefix.
 
 ## Language-Specific References
 

--- a/benchmarks/ecosystem-doctor-snapshot.json
+++ b/benchmarks/ecosystem-doctor-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "last_run": "2026-09-04T08:36:45Z",
+  "last_run": "2026-09-06T10:57:58Z",
   "schema_version": 1,
   "tools": {
     "aider": {
@@ -24,7 +24,7 @@
       }
     },
     "augment": {
-      "docs_hash": "0e91c48495240138",
+      "docs_hash": "4433eb23da85627b",
       "headings": [
         "Admin",
         "Auggie CLI",
@@ -66,7 +66,7 @@
       }
     },
     "claude-app": {
-      "docs_hash": "4ba2582ffb78c262",
+      "docs_hash": "96c2c218b4114aa2",
       "headings": [
         "Add global and folder instructions",
         "Availability",
@@ -108,7 +108,7 @@
       }
     },
     "claude-code": {
-      "docs_hash": "10fe9c9fa45efb7a",
+      "docs_hash": "fc44b0aa32724d83",
       "headings": [
         "Core concepts",
         "Documentation Index",
@@ -174,10 +174,10 @@
         "userConfig": false,
         "workflows": true
       },
-      "version": "2.1.260 (Claude Code)"
+      "version": "2.1.261 (Claude Code)"
     },
     "cline": {
-      "docs_hash": "53d71ba66743ef56",
+      "docs_hash": "3eaa2ce9bdeca974",
       "headings": [
         "API Reference",
         "Best Practices",
@@ -225,7 +225,7 @@
       }
     },
     "codex-cli": {
-      "docs_hash": "5444e9c3b6b4d284",
+      "docs_hash": "7ec73a39c311fc6d",
       "headings": [
         "API",
         "API Reference",
@@ -365,10 +365,10 @@
         "plugin marketplace": false,
         "sandbox": true
       },
-      "version": "codex-cli 0.153.2"
+      "version": "codex-cli 0.153.4"
     },
     "cursor": {
-      "docs_hash": "328f32fe1afe3e7e",
+      "docs_hash": "e7386e178a24d763",
       "headings": [
         "Agent",
         "CLI",
@@ -412,7 +412,7 @@
       }
     },
     "gemini-cli": {
-      "docs_hash": "b78dde41b3161819",
+      "docs_hash": "49b209908052dcd3",
       "headings": [
         "Breadcrumbs",
         "Directory actions",
@@ -453,7 +453,7 @@
       "version": "0.57.0"
     },
     "github-copilot": {
-      "docs_hash": "606c4417d0acebed",
+      "docs_hash": "59f851bcfd562e8c",
       "headings": [
         "About Copilot auto model selection",
         "About Copilot automations",
@@ -517,7 +517,7 @@
       }
     },
     "opencode": {
-      "docs_hash": "4dac69e305e60373",
+      "docs_hash": "7ea97688e7b24c4f",
       "headings": [
         "Add features",
         "Ask questions",
@@ -579,7 +579,7 @@
       }
     },
     "windsurf": {
-      "docs_hash": "121e915ebbd89355",
+      "docs_hash": "bcfc29ef31cabfba",
       "headings": [
         "Accounts",
         "Advanced",

--- a/kb/procedures/sop-post-release-testing.md
+++ b/kb/procedures/sop-post-release-testing.md
@@ -3,10 +3,10 @@ title: "SOP: Post-Release Testing"
 category: procedures
 service: ai-toolkit
 tags: [sop, post-release, smoke-test, npm, sandbox, plugin-pack, provenance, isolation]
-version: "1.2.0"
+version: "1.2.1"
 created: "2026-07-26"
-last_updated: "2026-08-19"
-description: "Smoke-test a published @softspark/ai-toolkit release from npm in an isolated HOME and npm prefix, without touching the maintainer's real install. Covers provenance, CLI, doctor, per-skill script resolution, scanner wiring, and the full plugin-pack lifecycle including the degraded-install path. Written for v4.18.0 and not run; v4.18.0 shipped a pack that broke every command it touched. First actually run on v4.22.0, which added Phases 4b and 4c after that release fixed four skills whose documented script path had never resolved and two that shipped a scanner nothing invoked."
+last_updated: "2026-09-06"
+description: "Smoke-test a published @softspark/ai-toolkit npm artifact in a disposable container or VM with its default HOME, no host settings or credential mounts, host-side configuration fingerprints, and retained evidence. Covers provenance, CLI, doctor, installed skill scripts, scanner wiring, and the plugin-pack lifecycle."
 ---
 
 # SOP: Post-Release Testing
@@ -16,43 +16,118 @@ actually install, from npm, rather than the working tree.
 
 Sibling procedures exist for `jira-mcp` and `legal-pl-pack`; this is the
 ai-toolkit equivalent. It complements
-[Release Verification](sop-release-verification.md), which checks the toolkit
-from the maintainer's own installed copy. The difference that matters: this one
-never writes to the maintainer's `~/.claude` or `~/.softspark`.
+[Release Verification](sop-release-verification.md), whose cross-editor checks
+must use the same isolated published artifact. Neither procedure installs or
+updates the maintainer's working copy.
 
 **Time:** 10 minutes.
 
 ## Why isolation is the first step, not a detail
 
-The toolkit installs into `$HOME`. Testing a release against your own HOME
-means the test either pollutes your working setup or, worse, passes because of
-state your setup already had. Both make the result meaningless.
+The toolkit writes settings beneath the current user's home directory. Run the
+published artifact in a disposable Docker container or VM with its normal HOME.
+Do not override host HOME, CODEX_HOME, or another editor's configuration root as
+a substitute for isolation. Do not expose the host home, credentials, SSH agent,
+Docker socket, or existing toolkit installation to the test environment.
 
-Every command below runs against a throwaway HOME and a throwaway npm prefix.
-Nothing is global.
+## Phase 1: Create and verify an isolated test environment
 
-## Phase 1: Sandbox
+The recipe below uses Docker. A disposable VM is equivalent only when host shared
+folders and authentication forwarding are absent. The host needs Docker and
+Python 3; the container prerequisites are installed separately below.
 
-```bash
-SB=$(mktemp -d)
-mkdir -p "$SB/home" "$SB/npm"
-export HOME="$SB/home"
-AT="$SB/npm/bin/ai-toolkit"
-echo "sandbox: $SB"
-```
-
-Record the real state now, so Phase 7 can prove it is unchanged:
+**Host terminal:** keep this terminal open for Phases 7 and 8. The fingerprint
+reads only these toolkit-managed settings files and records hashes and presence,
+never their contents. Add a path only after verifying that the tested installer
+actually manages it.
 
 ```bash
-python3 -c "
-import json, pathlib
-p = pathlib.Path('$SB/../real-before.json')
+set -o pipefail
+VERSION="X.Y.Z"
+EVIDENCE=$(mktemp -d "${TMPDIR:-/tmp}/ai-toolkit-release-${VERSION}.XXXXXX")
+SMOKE_CONTAINER=$(python3 -c 'import uuid; print("ai-toolkit-smoke-" + uuid.uuid4().hex)')
+
+fingerprint_host() {
+  python3 - <<'PY'
+import hashlib
+import json
 import os
-home = pathlib.Path(os.path.expanduser('~'))
-" 2>/dev/null
-# Simpler: note what exists today.
-cat ~/.softspark/ai-toolkit/plugins.json 2>/dev/null
+from pathlib import Path
+
+home = Path.home()
+managed = [
+    ".claude/settings.json",
+    ".claude.json",
+    ".softspark/ai-toolkit/plugins.json",
+    ".codex/config.toml",
+    ".cursor/mcp.json",
+    ".gemini/settings.json",
+    ".config/opencode/opencode.json",
+]
+rows = {}
+for relative in managed:
+    path = home / relative
+    row = {"exists": path.exists() or path.is_symlink()}
+    if path.is_symlink():
+        row["link_sha256"] = hashlib.sha256(os.readlink(path).encode()).hexdigest()
+    if path.is_file():
+        row["sha256"] = hashlib.sha256(path.read_bytes()).hexdigest()
+    rows[relative] = row
+print(json.dumps({
+    "host_home_sha256": hashlib.sha256(str(home).encode()).hexdigest(),
+    "files": rows,
+}, sort_keys=True, indent=2))
+PY
+}
+
+fingerprint_host > "$EVIDENCE/host-before.json"
+docker run -d --name "$SMOKE_CONTAINER" \
+  --label "org.softspark.release-smoke=$SMOKE_CONTAINER" \
+  --env "VERSION=$VERSION" \
+  node:22-bookworm sleep infinity
+docker inspect "$SMOKE_CONTAINER" > "$EVIDENCE/container-before.json"
+python3 - "$EVIDENCE/container-before.json" <<'PY'
+import json
+import sys
+
+container = json.load(open(sys.argv[1], encoding="utf-8"))[0]
+assert container["Mounts"] == [], "Smoke container must have no mounts"
+host = container["HostConfig"]
+assert not host["Privileged"], "Privileged containers are forbidden"
+assert host["NetworkMode"] != "host", "Do not share the host network namespace"
+assert host["PidMode"] != "host", "Do not share host processes"
+PY
+docker exec "$SMOKE_CONTAINER" bash -lc \
+  'test "$HOME" = "$(getent passwd "$(id -u)" | cut -d: -f6)"'
+docker exec "$SMOKE_CONTAINER" bash -lc \
+  'apt-get update && apt-get install -y --no-install-recommends python3 python3-yaml git coreutils jq bats shellcheck ca-certificates curl util-linux' \
+  2>&1 | tee "$EVIDENCE/bootstrap.log"
 ```
+
+Install any additional prerequisite declared by the pack under test only inside
+the container. GNU coreutils supplies timeout; util-linux supplies the session
+recorder. Use docker cp for evidence transfer, not host temporary-directory bind
+mounts: a remote Docker daemon may not see the host's /private/tmp.
+
+**Enter the container, then run Phases 2 through 6 there:**
+
+```bash
+docker exec -it "$SMOKE_CONTAINER" bash
+```
+
+Inside that container shell:
+
+```bash
+SB=/tmp/ai-toolkit-smoke
+AT="$SB/npm/bin/ai-toolkit"
+mkdir -p "$SB/npm" "$SB/evidence"
+export SB AT
+exec script -q -e -a "$SB/evidence/session.log" -c 'bash --noprofile --norc'
+```
+
+Keep HOME at the container user's default. VERSION was passed when the container
+was created; SB and the npm prefix are disposable container paths. No command in
+Phases 2 through 6 runs in the host shell.
 
 ## Phase 2: Provenance
 
@@ -60,29 +135,28 @@ Do this before installing anything: an unsigned publish is a release-blocking
 regression, and there is no point smoke-testing a build you would have to redo.
 
 ```bash
-VERSION="X.Y.Z"
-npm view "@softspark/ai-toolkit@${VERSION}" --json \
-  | python3 -c "
+npm view "@softspark/ai-toolkit@${VERSION}" --json > "$SB/evidence/npm-view.json"
+python3 -c "
 import json, sys
-d = json.load(sys.stdin); att = d['dist'].get('attestations', {})
+d = json.load(open(sys.argv[1], encoding='utf-8')); att = d['dist'].get('attestations', {})
 pt = att.get('provenance', {}).get('predicateType')
 assert pt == 'https://slsa.dev/provenance/v1', f'NO PROVENANCE: {pt}'
 print('PROVENANCE OK:', att['url'])
-"
+" "$SB/evidence/npm-view.json"
 ```
 
 ## Phase 3: Install from npm
 
 ```bash
 npm install -g --prefix "$SB/npm" "@softspark/ai-toolkit@${VERSION}"
-"$AT" --version    # must equal VERSION
+"$AT" --version | tee "$SB/evidence/version.txt"    # must equal VERSION
 "$AT" --help >/dev/null && echo "help OK"
 ```
 
 ## Phase 4: Core surfaces
 
 ```bash
-"$AT" install            # full global install into the sandbox HOME
+"$AT" install            # global install inside the container's default HOME
 "$AT" doctor             # must end: Errors: 0 | Warnings: 0
 "$AT" status
 "$AT" plugin list        # pack count must match app/plugins/
@@ -120,8 +194,13 @@ for D in "$HOME"/.claude/skills/*/; do
   rel=${ref##*\$\{CLAUDE_SKILL_DIR\}/}
   printf '%-22s %-10s %-26s ' "$s" "$interp" "$rel"
   [ -f "$D/$rel" ] || { echo 'PATH DOES NOT RESOLVE'; continue; }
-  out=$(CLAUDE_SKILL_DIR="$D" timeout 20 "$interp" "$D/$rel" --help </dev/null 2>&1 | head -1)
-  printf 'rc=%s %s\n' "$?" "$(echo "$out" | cut -c1-40)"
+  if out=$(CLAUDE_SKILL_DIR="$D" timeout 20 "$interp" "$D/$rel" --help </dev/null 2>&1); then
+    rc=0
+  else
+    rc=$?
+  fi
+  printf '%s\n' "$out" > "$SB/evidence/skill-$s.log"
+  printf 'rc=%s %s\n' "$rc" "$(printf '%s\n' "$out" | head -1 | cut -c1-40)"
 done
 ```
 
@@ -262,36 +341,58 @@ again, pointing its source-override variable at a dead URL:
 - [ ] `plugin status` says the pack is inert and names the fix
 - [ ] Re-installing without the broken source recovers
 
-## Phase 7: Prove the real environment is untouched
+## Phase 7: Verify the host configuration
+
+Exit the recorded container shell. This returns to the unchanged host terminal
+from Phase 1. Run fingerprint_host there, not through docker exec and not in a
+shell that changed HOME:
 
 ```bash
-python3 -c "
-import json, pathlib
-d = json.loads(pathlib.Path.home().joinpath('.softspark/ai-toolkit/plugins.json').read_text())
-print('plugins.json:', d['targets']['claude'])
-p = pathlib.Path.home() / '.claude/settings.json'
-print('pack hook leaked into real settings:', '<pack>' in json.dumps(json.loads(p.read_text()).get('hooks', {})) if p.exists() else False)
-print('pack paths in real ~/.softspark:', len(list(pathlib.Path.home().joinpath('.softspark').rglob('*<pack>*'))))
-"
+fingerprint_host > "$EVIDENCE/host-after.json"
+cmp -s "$EVIDENCE/host-before.json" "$EVIDENCE/host-after.json" || {
+  diff -u "$EVIDENCE/host-before.json" "$EVIDENCE/host-after.json"
+  echo "Host configuration changed: investigate before accepting the release."
+  exit 1
+}
+docker inspect "$SMOKE_CONTAINER" > "$EVIDENCE/container-after.json"
 ```
 
-All three must show the pre-test state.
+The fingerprints must match. This proves the enumerated managed settings stayed
+unchanged; the recorded container configuration separately proves there were no
+host mounts or shared host namespaces. Do not claim to have hashed the whole
+home directory, or print settings contents to demonstrate isolation.
 
-## Phase 8: Clean up
+## Phase 8: Preserve evidence and remove only the owned container
 
-`guard-destructive.sh` blocks `rm -rf` on a `PreToolUse` hook, so removal goes
-through an enumerated delete that reports what it removed:
+Run on the host, after leaving the container shell. Confirm ownership before any
+cleanup, then copy the recorded session, npm provenance metadata, and CLI version.
+Keep the host evidence directory for the release record.
 
 ```bash
-python3 -c "
-import pathlib, shutil
-sb = pathlib.Path('$SB')
-assert sb.is_dir() and str(sb).startswith(('/tmp', '/var/folders')), sb
-n = sum(1 for _ in sb.rglob('*') if _.is_file())
-shutil.rmtree(sb)
-print(f'removed {sb} ({n} files)')
-"
+test "$(docker inspect --format '{{index .Config.Labels "org.softspark.release-smoke"}}' "$SMOKE_CONTAINER")" = "$SMOKE_CONTAINER" || {
+  echo "Container ownership does not match; refusing cleanup."
+  exit 1
+}
+docker logs "$SMOKE_CONTAINER" > "$EVIDENCE/container.log" 2>&1
+mkdir -p "$EVIDENCE/container"
+docker cp "$SMOKE_CONTAINER:/tmp/ai-toolkit-smoke/evidence/." "$EVIDENCE/container/" || {
+  echo "Evidence transfer failed; keep the container and investigate."
+  exit 1
+}
+test -f "$EVIDENCE/container/session.log" || {
+  echo "Session evidence is missing; refusing cleanup."
+  exit 1
+}
+docker stop "$SMOKE_CONTAINER"
+docker rm "$SMOKE_CONTAINER"
+printf 'Evidence retained: %s\n' "$EVIDENCE"
 ```
+
+There are no host bind mounts or named volumes to delete. Never bypass a
+destructive-command guard with Python, shutil.rmtree, another interpreter, or a
+different deletion tool. If a guard rejects cleanup, leave the owned container
+and evidence in place and report the rejection through the normal approval
+mechanism. Do not prune Docker resources or delete unrelated temporary files.
 
 ## Success criteria
 
@@ -306,10 +407,10 @@ print(f'removed {sb} ({n} files)')
 | Pack update | Current version silent; stale version updates and re-records |
 | Pack removal | Zero residue in `~/.softspark` and `settings.json`; re-install works |
 | Degraded path | Fetch failure is inert, loud in status, and recoverable |
-| Isolation | Real `~/.claude` and `~/.softspark` byte-identical to pre-test |
+| Isolation | Host-side managed-settings fingerprints match; container has no host mounts or shared host namespaces |
 
 ## Related
 
 - [Release Preparation](sop-release.md) — run before tagging
-- [Release Verification](sop-release-verification.md) — the maintainer-install checks
+- [Release Verification](sop-release-verification.md) — cross-editor checks of the isolated npm artifact
 - [rtk-pack Retirement](../history/completed/rtk-pack-retirement-20260727.md) — what happened the one time this SOP was written and not run

--- a/kb/procedures/sop-release-verification.md
+++ b/kb/procedures/sop-release-verification.md
@@ -3,9 +3,9 @@ title: "SOP: Release Verification"
 category: procedures
 service: ai-toolkit
 tags: [sop, verification, release, smoke-test, install, update, qa, provenance, sarif, dsh]
-version: "1.8.0"
+version: "1.8.1"
 created: "2026-04-08"
-last_updated: "2026-09-01"
+last_updated: "2026-09-06"
 description: "End-to-end smoke test after installing or updating @softspark/ai-toolkit. Verifies CLI, native Codex and GitHub Copilot surfaces, explicit DSH lifecycle, Claude app export, doctor, validation, tests, eject, provenance, SARIF, and per-skill permissions."
 ---
 
@@ -23,9 +23,27 @@ Verifies all critical paths from the user's perspective.
 
 **Prerequisites:**
 - Node.js >= 18, Python 3, `bats`, git
-- `@softspark/ai-toolkit` installed globally
+- The target version of `@softspark/ai-toolkit` installed in a disposable test environment
 
 **Time:** 10-15 minutes (full), 2 minutes (quick checklist)
+
+---
+
+## Verification environment
+
+Run installation, update, eject and editor smoke checks in a disposable
+container or VM with its own OS user and default home directory. Do not
+reassign `HOME` or `CODEX_HOME`, mount the operator's home/authentication
+directories, or alter the global installation used by an active session.
+Use the packed release candidate before publication and the exact npm version
+after publication; the installed package must be the source of runtime checks.
+Source validation and test commands still run from the matching release checkout.
+
+A scratch project alone does not isolate home-scoped writes. In particular,
+the live Augment checks in Phase 9 write user settings. Execute them inside
+the disposable environment, retain logs outside it, and remove only resources
+created for this verification run. Do not treat a dry-run as proof that emitted
+files parse or that a second install is idempotent.
 
 ---
 
@@ -123,9 +141,11 @@ ai-toolkit status
 ```
 
 **Verify `--dry-run`:**
-- [ ] Agents: 44
-- [ ] Skills: 108
-- [ ] Hooks merged into settings.json
+- [ ] Agent and skill totals match the target package's `app/agents/` and
+      `app/skills/*/SKILL.md` inventory; compare with that release's validator
+      output and README badges, not a number copied from an older release
+- [ ] Dry-run describes the planned hook merge; the isolated installed copy
+      contains the expected hooks in settings.json
 - [ ] "Other AI Tools" lists documented global targets (with `--editors`): aider, antigravity, augment, cline, codex, copilot, cursor, gemini, opencode, roo, windsurf. Scope varies: Codex uses `$CODEX_HOME` (default `~/.codex`) plus `$HOME/.agents/skills`; Copilot uses `$COPILOT_HOME` (default `~/.copilot`); cursor has only `~/.cursor/hooks.json`; antigravity has the `~/.gemini/*/skills` pointer. Cursor and Antigravity rules remain project-only.
 
 **Verify `status`:**
@@ -195,9 +215,12 @@ python3 scripts/audit_skills.py --ci
 ```
 
 **Verify validate.py:**
-- [ ] Agents: 44, Skills: 108, Tests: exactly the current README badge count
-- [ ] Hook events: 14, Hook scripts: >= 30
-- [ ] Plugin packs >= 10, KB documents >= 20
+- [ ] Agent, skill and Bats test totals match the current release inventory
+      and README badges, as checked by the validator's metadata contracts
+- [ ] Hook events/scripts match `app/hooks.json` and the shipped hook files
+- [ ] Every shipped plugin pack and KB document passes its validator; compare
+      inventory with the release checkout rather than requiring an obsolete
+      fixed minimum number of packs or documents
 - [ ] `Errors: 0 | Warnings: 0` → `VALIDATION PASSED`
 
 **Verify audit_skills.py:**
@@ -210,7 +233,7 @@ python3 scripts/audit_skills.py --ci
 ## Phase 6: Tests (3-5 min)
 
 ```bash
-# Run ONCE, capture to file, then parse. Full suite is 669+ bats cases —
+# Run ONCE, capture to file, then parse. Use the current release's Bats count;
 # re-running it per check (tail / grep ok / grep not ok piped separately)
 # wastes minutes every release. Always cache the output.
 npm test > /tmp/npm-test.log 2>&1
@@ -223,7 +246,7 @@ echo "exit:   $exit"
 
 **Verify:**
 - [ ] `exit == 0`
-- [ ] `ok == expected test count` (e.g., 945 on v3.0.0)
+- [ ] `ok == expected test count` from the current release's metadata contracts
 - [ ] `not ok == 0`
 - [ ] Bats runs tests in parallel (4 jobs)
 - [ ] Groups: agents, autodetect, cli, generators, guards, hooks, inject,
@@ -334,7 +357,7 @@ AI_TOOLKIT_STRICT_PIN=1 ai-toolkit update --dry-run
 
 These verify the native-surface generators shipped in v3.0.0 actually emit the right files for the right profiles, and that the tool registry stays in sync with shipped generators.
 
-> **Safety warning — HOME-scoped writes:** Running `--profile full` with `augment` in the editor list writes to `$HOME/.augment/settings.json` (Augment stores hooks under HOME, not per-project). Use `--dry-run` for verification unless you intend to carry ai-toolkit hook entries on this machine. The generator is marker-safe (only rewrites its own `_source: ai-toolkit` entries) but is still a side-effect.
+> Run this phase inside the disposable verification environment. `--profile full` with `augment` writes to `$HOME/.augment/settings.json`, so a temporary project on the operator's machine is insufficient. Dry-run checks cover the planned paths; Phases 9.4 and 9.5 must also exercise actual writes in isolation.
 
 ### 9.1 `--profile full` emits every native surface
 
@@ -411,7 +434,9 @@ The bats suite validates JSON shape at generation time. This re-checks that what
 D=/tmp/aitk-json-${RANDOM} && mkdir -p "$D" && cd "$D" && git init -q
 ai-toolkit install --local --editors cursor,windsurf,gemini,augment,codex,copilot --profile full >/dev/null 2>&1
 for f in .cursor/hooks.json .devin/hooks.v1.json .gemini/settings.json .codex/hooks.json .github/hooks/ai-toolkit.json "$HOME/.augment/settings.json"; do
-  [ -f "$f" ] && python3 -c "import json; json.load(open('$f'))" && echo "OK: $f"
+  [ -f "$f" ] || { echo "MISSING: $f"; exit 1; }
+  python3 -c 'import json, sys; json.load(open(sys.argv[1]))' "$f" || exit 1
+  echo "OK: $f"
 done
 ```
 

--- a/kb/procedures/sop-release.md
+++ b/kb/procedures/sop-release.md
@@ -3,9 +3,9 @@ title: "SOP: Release Preparation"
 category: procedures
 service: ai-toolkit
 tags: [sop, release, version, publish, changelog, semver, provenance, sarif, ecosystem, shellcheck]
-version: "1.15.0"
+version: "1.15.1"
 created: "2026-04-10"
-last_updated: "2026-09-02"
+last_updated: "2026-09-06"
 description: "Step-by-step checklist for preparing a new ai-toolkit release — ecosystem-sync drift check, version sync, changelog, artifact regeneration, validation, branch CI, and tagging. Run BEFORE every git tag. Includes mandatory Provenance, SARIF, checksum-pin, ShellCheck, licensing, exact-tag assertions, and a green Ubuntu/macOS branch-CI gate before any release tag is created."
 ---
 
@@ -14,6 +14,13 @@ description: "Step-by-step checklist for preparing a new ai-toolkit release — 
 Complete checklist for preparing a new `@softspark/ai-toolkit` release.
 Run this **before** tagging. After tagging and publishing, run the
 [Release Verification SOP](sop-release-verification.md) to smoke-test.
+
+Installation smoke uses a disposable container or VM with its own default
+home directory, as described in the verification SOP. Test the packed release
+candidate before publishing and the exact npm version afterward. Keep the
+operator's installed toolkit, editor settings and authentication directories
+outside that environment. Compare component counts with the current release
+inventory and validator output instead of historical constants in a checklist.
 
 **Pipeline:**
 ```

--- a/kb/reference/architecture-overview.md
+++ b/kb/reference/architecture-overview.md
@@ -3,9 +3,9 @@ title: "AI Toolkit - Architecture Overview"
 category: reference
 service: ai-toolkit
 tags: [architecture, overview, design, structure]
-version: "1.10.0"
+version: "1.10.1"
 created: "2026-03-23"
-last_updated: "2026-09-01"
+last_updated: "2026-09-06"
 description: "Architecture of ai-toolkit: install ownership, runtime adapters, the explicit DSH target, skill tiers, and project integration."
 ---
 
@@ -315,7 +315,7 @@ Agents (code-reviewer, debugger, devops-implementer, ...)
 
 ## Quality Hooks
 
-29 entries across 14 lifecycle events. See [hooks-catalog.md](hooks-catalog.md) for full details.
+28 entries across 14 lifecycle events. See [hooks-catalog.md](hooks-catalog.md) for full details.
 
 | Hook | Trigger | Script | Action |
 |------|---------|--------|--------|

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -7721,10 +7721,10 @@ title: "SOP: Post-Release Testing"
 category: procedures
 service: ai-toolkit
 tags: [sop, post-release, smoke-test, npm, sandbox, plugin-pack, provenance, isolation]
-version: "1.2.0"
+version: "1.2.1"
 created: "2026-07-26"
-last_updated: "2026-08-19"
-description: "Smoke-test a published @softspark/ai-toolkit release from npm in an isolated HOME and npm prefix, without touching the maintainer's real install. Covers provenance, CLI, doctor, per-skill script resolution, scanner wiring, and the full plugin-pack lifecycle including the degraded-install path. Written for v4.18.0 and not run; v4.18.0 shipped a pack that broke every command it touched. First actually run on v4.22.0, which added Phases 4b and 4c after that release fixed four skills whose documented script path had never resolved and two that shipped a scanner nothing invoked."
+last_updated: "2026-09-06"
+description: "Smoke-test a published @softspark/ai-toolkit npm artifact in a disposable container or VM with its default HOME, no host settings or credential mounts, host-side configuration fingerprints, and retained evidence. Covers provenance, CLI, doctor, installed skill scripts, scanner wiring, and the plugin-pack lifecycle."
 ---
 
 # SOP: Post-Release Testing
@@ -7734,43 +7734,118 @@ actually install, from npm, rather than the working tree.
 
 Sibling procedures exist for `jira-mcp` and `legal-pl-pack`; this is the
 ai-toolkit equivalent. It complements
-[Release Verification](sop-release-verification.md), which checks the toolkit
-from the maintainer's own installed copy. The difference that matters: this one
-never writes to the maintainer's `~/.claude` or `~/.softspark`.
+[Release Verification](sop-release-verification.md), whose cross-editor checks
+must use the same isolated published artifact. Neither procedure installs or
+updates the maintainer's working copy.
 
 **Time:** 10 minutes.
 
 ## Why isolation is the first step, not a detail
 
-The toolkit installs into `$HOME`. Testing a release against your own HOME
-means the test either pollutes your working setup or, worse, passes because of
-state your setup already had. Both make the result meaningless.
+The toolkit writes settings beneath the current user's home directory. Run the
+published artifact in a disposable Docker container or VM with its normal HOME.
+Do not override host HOME, CODEX_HOME, or another editor's configuration root as
+a substitute for isolation. Do not expose the host home, credentials, SSH agent,
+Docker socket, or existing toolkit installation to the test environment.
 
-Every command below runs against a throwaway HOME and a throwaway npm prefix.
-Nothing is global.
+## Phase 1: Create and verify an isolated test environment
 
-## Phase 1: Sandbox
+The recipe below uses Docker. A disposable VM is equivalent only when host shared
+folders and authentication forwarding are absent. The host needs Docker and
+Python 3; the container prerequisites are installed separately below.
 
-```bash
-SB=$(mktemp -d)
-mkdir -p "$SB/home" "$SB/npm"
-export HOME="$SB/home"
-AT="$SB/npm/bin/ai-toolkit"
-echo "sandbox: $SB"
-```
-
-Record the real state now, so Phase 7 can prove it is unchanged:
+**Host terminal:** keep this terminal open for Phases 7 and 8. The fingerprint
+reads only these toolkit-managed settings files and records hashes and presence,
+never their contents. Add a path only after verifying that the tested installer
+actually manages it.
 
 ```bash
-python3 -c "
-import json, pathlib
-p = pathlib.Path('$SB/../real-before.json')
+set -o pipefail
+VERSION="X.Y.Z"
+EVIDENCE=$(mktemp -d "${TMPDIR:-/tmp}/ai-toolkit-release-${VERSION}.XXXXXX")
+SMOKE_CONTAINER=$(python3 -c 'import uuid; print("ai-toolkit-smoke-" + uuid.uuid4().hex)')
+
+fingerprint_host() {
+  python3 - <<'PY'
+import hashlib
+import json
 import os
-home = pathlib.Path(os.path.expanduser('~'))
-" 2>/dev/null
-# Simpler: note what exists today.
-cat ~/.softspark/ai-toolkit/plugins.json 2>/dev/null
+from pathlib import Path
+
+home = Path.home()
+managed = [
+    ".claude/settings.json",
+    ".claude.json",
+    ".softspark/ai-toolkit/plugins.json",
+    ".codex/config.toml",
+    ".cursor/mcp.json",
+    ".gemini/settings.json",
+    ".config/opencode/opencode.json",
+]
+rows = {}
+for relative in managed:
+    path = home / relative
+    row = {"exists": path.exists() or path.is_symlink()}
+    if path.is_symlink():
+        row["link_sha256"] = hashlib.sha256(os.readlink(path).encode()).hexdigest()
+    if path.is_file():
+        row["sha256"] = hashlib.sha256(path.read_bytes()).hexdigest()
+    rows[relative] = row
+print(json.dumps({
+    "host_home_sha256": hashlib.sha256(str(home).encode()).hexdigest(),
+    "files": rows,
+}, sort_keys=True, indent=2))
+PY
+}
+
+fingerprint_host > "$EVIDENCE/host-before.json"
+docker run -d --name "$SMOKE_CONTAINER" \
+  --label "org.softspark.release-smoke=$SMOKE_CONTAINER" \
+  --env "VERSION=$VERSION" \
+  node:22-bookworm sleep infinity
+docker inspect "$SMOKE_CONTAINER" > "$EVIDENCE/container-before.json"
+python3 - "$EVIDENCE/container-before.json" <<'PY'
+import json
+import sys
+
+container = json.load(open(sys.argv[1], encoding="utf-8"))[0]
+assert container["Mounts"] == [], "Smoke container must have no mounts"
+host = container["HostConfig"]
+assert not host["Privileged"], "Privileged containers are forbidden"
+assert host["NetworkMode"] != "host", "Do not share the host network namespace"
+assert host["PidMode"] != "host", "Do not share host processes"
+PY
+docker exec "$SMOKE_CONTAINER" bash -lc \
+  'test "$HOME" = "$(getent passwd "$(id -u)" | cut -d: -f6)"'
+docker exec "$SMOKE_CONTAINER" bash -lc \
+  'apt-get update && apt-get install -y --no-install-recommends python3 python3-yaml git coreutils jq bats shellcheck ca-certificates curl util-linux' \
+  2>&1 | tee "$EVIDENCE/bootstrap.log"
 ```
+
+Install any additional prerequisite declared by the pack under test only inside
+the container. GNU coreutils supplies timeout; util-linux supplies the session
+recorder. Use docker cp for evidence transfer, not host temporary-directory bind
+mounts: a remote Docker daemon may not see the host's /private/tmp.
+
+**Enter the container, then run Phases 2 through 6 there:**
+
+```bash
+docker exec -it "$SMOKE_CONTAINER" bash
+```
+
+Inside that container shell:
+
+```bash
+SB=/tmp/ai-toolkit-smoke
+AT="$SB/npm/bin/ai-toolkit"
+mkdir -p "$SB/npm" "$SB/evidence"
+export SB AT
+exec script -q -e -a "$SB/evidence/session.log" -c 'bash --noprofile --norc'
+```
+
+Keep HOME at the container user's default. VERSION was passed when the container
+was created; SB and the npm prefix are disposable container paths. No command in
+Phases 2 through 6 runs in the host shell.
 
 ## Phase 2: Provenance
 
@@ -7778,29 +7853,28 @@ Do this before installing anything: an unsigned publish is a release-blocking
 regression, and there is no point smoke-testing a build you would have to redo.
 
 ```bash
-VERSION="X.Y.Z"
-npm view "@softspark/ai-toolkit@${VERSION}" --json \
-  | python3 -c "
+npm view "@softspark/ai-toolkit@${VERSION}" --json > "$SB/evidence/npm-view.json"
+python3 -c "
 import json, sys
-d = json.load(sys.stdin); att = d['dist'].get('attestations', {})
+d = json.load(open(sys.argv[1], encoding='utf-8')); att = d['dist'].get('attestations', {})
 pt = att.get('provenance', {}).get('predicateType')
 assert pt == 'https://slsa.dev/provenance/v1', f'NO PROVENANCE: {pt}'
 print('PROVENANCE OK:', att['url'])
-"
+" "$SB/evidence/npm-view.json"
 ```
 
 ## Phase 3: Install from npm
 
 ```bash
 npm install -g --prefix "$SB/npm" "@softspark/ai-toolkit@${VERSION}"
-"$AT" --version    # must equal VERSION
+"$AT" --version | tee "$SB/evidence/version.txt"    # must equal VERSION
 "$AT" --help >/dev/null && echo "help OK"
 ```
 
 ## Phase 4: Core surfaces
 
 ```bash
-"$AT" install            # full global install into the sandbox HOME
+"$AT" install            # global install inside the container's default HOME
 "$AT" doctor             # must end: Errors: 0 | Warnings: 0
 "$AT" status
 "$AT" plugin list        # pack count must match app/plugins/
@@ -7838,8 +7912,13 @@ for D in "$HOME"/.claude/skills/*/; do
   rel=${ref##*\$\{CLAUDE_SKILL_DIR\}/}
   printf '%-22s %-10s %-26s ' "$s" "$interp" "$rel"
   [ -f "$D/$rel" ] || { echo 'PATH DOES NOT RESOLVE'; continue; }
-  out=$(CLAUDE_SKILL_DIR="$D" timeout 20 "$interp" "$D/$rel" --help </dev/null 2>&1 | head -1)
-  printf 'rc=%s %s\n' "$?" "$(echo "$out" | cut -c1-40)"
+  if out=$(CLAUDE_SKILL_DIR="$D" timeout 20 "$interp" "$D/$rel" --help </dev/null 2>&1); then
+    rc=0
+  else
+    rc=$?
+  fi
+  printf '%s\n' "$out" > "$SB/evidence/skill-$s.log"
+  printf 'rc=%s %s\n' "$rc" "$(printf '%s\n' "$out" | head -1 | cut -c1-40)"
 done
 ```
 
@@ -7980,36 +8059,58 @@ again, pointing its source-override variable at a dead URL:
 - [ ] `plugin status` says the pack is inert and names the fix
 - [ ] Re-installing without the broken source recovers
 
-## Phase 7: Prove the real environment is untouched
+## Phase 7: Verify the host configuration
+
+Exit the recorded container shell. This returns to the unchanged host terminal
+from Phase 1. Run fingerprint_host there, not through docker exec and not in a
+shell that changed HOME:
 
 ```bash
-python3 -c "
-import json, pathlib
-d = json.loads(pathlib.Path.home().joinpath('.softspark/ai-toolkit/plugins.json').read_text())
-print('plugins.json:', d['targets']['claude'])
-p = pathlib.Path.home() / '.claude/settings.json'
-print('pack hook leaked into real settings:', '<pack>' in json.dumps(json.loads(p.read_text()).get('hooks', {})) if p.exists() else False)
-print('pack paths in real ~/.softspark:', len(list(pathlib.Path.home().joinpath('.softspark').rglob('*<pack>*'))))
-"
+fingerprint_host > "$EVIDENCE/host-after.json"
+cmp -s "$EVIDENCE/host-before.json" "$EVIDENCE/host-after.json" || {
+  diff -u "$EVIDENCE/host-before.json" "$EVIDENCE/host-after.json"
+  echo "Host configuration changed: investigate before accepting the release."
+  exit 1
+}
+docker inspect "$SMOKE_CONTAINER" > "$EVIDENCE/container-after.json"
 ```
 
-All three must show the pre-test state.
+The fingerprints must match. This proves the enumerated managed settings stayed
+unchanged; the recorded container configuration separately proves there were no
+host mounts or shared host namespaces. Do not claim to have hashed the whole
+home directory, or print settings contents to demonstrate isolation.
 
-## Phase 8: Clean up
+## Phase 8: Preserve evidence and remove only the owned container
 
-`guard-destructive.sh` blocks `rm -rf` on a `PreToolUse` hook, so removal goes
-through an enumerated delete that reports what it removed:
+Run on the host, after leaving the container shell. Confirm ownership before any
+cleanup, then copy the recorded session, npm provenance metadata, and CLI version.
+Keep the host evidence directory for the release record.
 
 ```bash
-python3 -c "
-import pathlib, shutil
-sb = pathlib.Path('$SB')
-assert sb.is_dir() and str(sb).startswith(('/tmp', '/var/folders')), sb
-n = sum(1 for _ in sb.rglob('*') if _.is_file())
-shutil.rmtree(sb)
-print(f'removed {sb} ({n} files)')
-"
+test "$(docker inspect --format '{{index .Config.Labels "org.softspark.release-smoke"}}' "$SMOKE_CONTAINER")" = "$SMOKE_CONTAINER" || {
+  echo "Container ownership does not match; refusing cleanup."
+  exit 1
+}
+docker logs "$SMOKE_CONTAINER" > "$EVIDENCE/container.log" 2>&1
+mkdir -p "$EVIDENCE/container"
+docker cp "$SMOKE_CONTAINER:/tmp/ai-toolkit-smoke/evidence/." "$EVIDENCE/container/" || {
+  echo "Evidence transfer failed; keep the container and investigate."
+  exit 1
+}
+test -f "$EVIDENCE/container/session.log" || {
+  echo "Session evidence is missing; refusing cleanup."
+  exit 1
+}
+docker stop "$SMOKE_CONTAINER"
+docker rm "$SMOKE_CONTAINER"
+printf 'Evidence retained: %s\n' "$EVIDENCE"
 ```
+
+There are no host bind mounts or named volumes to delete. Never bypass a
+destructive-command guard with Python, shutil.rmtree, another interpreter, or a
+different deletion tool. If a guard rejects cleanup, leave the owned container
+and evidence in place and report the rejection through the normal approval
+mechanism. Do not prune Docker resources or delete unrelated temporary files.
 
 ## Success criteria
 
@@ -8024,12 +8125,12 @@ print(f'removed {sb} ({n} files)')
 | Pack update | Current version silent; stale version updates and re-records |
 | Pack removal | Zero residue in `~/.softspark` and `settings.json`; re-install works |
 | Degraded path | Fetch failure is inert, loud in status, and recoverable |
-| Isolation | Real `~/.claude` and `~/.softspark` byte-identical to pre-test |
+| Isolation | Host-side managed-settings fingerprints match; container has no host mounts or shared host namespaces |
 
 ## Related
 
 - [Release Preparation](sop-release.md) — run before tagging
-- [Release Verification](sop-release-verification.md) — the maintainer-install checks
+- [Release Verification](sop-release-verification.md) — cross-editor checks of the isolated npm artifact
 - [rtk-pack Retirement](../history/completed/rtk-pack-retirement-20260727.md) — what happened the one time this SOP was written and not run
 
 ---
@@ -8142,9 +8243,9 @@ title: "SOP: Release Verification"
 category: procedures
 service: ai-toolkit
 tags: [sop, verification, release, smoke-test, install, update, qa, provenance, sarif, dsh]
-version: "1.8.0"
+version: "1.8.1"
 created: "2026-04-08"
-last_updated: "2026-09-01"
+last_updated: "2026-09-06"
 description: "End-to-end smoke test after installing or updating @softspark/ai-toolkit. Verifies CLI, native Codex and GitHub Copilot surfaces, explicit DSH lifecycle, Claude app export, doctor, validation, tests, eject, provenance, SARIF, and per-skill permissions."
 ---
 
@@ -8162,9 +8263,27 @@ Verifies all critical paths from the user's perspective.
 
 **Prerequisites:**
 - Node.js >= 18, Python 3, `bats`, git
-- `@softspark/ai-toolkit` installed globally
+- The target version of `@softspark/ai-toolkit` installed in a disposable test environment
 
 **Time:** 10-15 minutes (full), 2 minutes (quick checklist)
+
+---
+
+## Verification environment
+
+Run installation, update, eject and editor smoke checks in a disposable
+container or VM with its own OS user and default home directory. Do not
+reassign `HOME` or `CODEX_HOME`, mount the operator's home/authentication
+directories, or alter the global installation used by an active session.
+Use the packed release candidate before publication and the exact npm version
+after publication; the installed package must be the source of runtime checks.
+Source validation and test commands still run from the matching release checkout.
+
+A scratch project alone does not isolate home-scoped writes. In particular,
+the live Augment checks in Phase 9 write user settings. Execute them inside
+the disposable environment, retain logs outside it, and remove only resources
+created for this verification run. Do not treat a dry-run as proof that emitted
+files parse or that a second install is idempotent.
 
 ---
 
@@ -8262,9 +8381,11 @@ ai-toolkit status
 ```
 
 **Verify `--dry-run`:**
-- [ ] Agents: 44
-- [ ] Skills: 108
-- [ ] Hooks merged into settings.json
+- [ ] Agent and skill totals match the target package's `app/agents/` and
+      `app/skills/*/SKILL.md` inventory; compare with that release's validator
+      output and README badges, not a number copied from an older release
+- [ ] Dry-run describes the planned hook merge; the isolated installed copy
+      contains the expected hooks in settings.json
 - [ ] "Other AI Tools" lists documented global targets (with `--editors`): aider, antigravity, augment, cline, codex, copilot, cursor, gemini, opencode, roo, windsurf. Scope varies: Codex uses `$CODEX_HOME` (default `~/.codex`) plus `$HOME/.agents/skills`; Copilot uses `$COPILOT_HOME` (default `~/.copilot`); cursor has only `~/.cursor/hooks.json`; antigravity has the `~/.gemini/*/skills` pointer. Cursor and Antigravity rules remain project-only.
 
 **Verify `status`:**
@@ -8334,9 +8455,12 @@ python3 scripts/audit_skills.py --ci
 ```
 
 **Verify validate.py:**
-- [ ] Agents: 44, Skills: 108, Tests: exactly the current README badge count
-- [ ] Hook events: 14, Hook scripts: >= 30
-- [ ] Plugin packs >= 10, KB documents >= 20
+- [ ] Agent, skill and Bats test totals match the current release inventory
+      and README badges, as checked by the validator's metadata contracts
+- [ ] Hook events/scripts match `app/hooks.json` and the shipped hook files
+- [ ] Every shipped plugin pack and KB document passes its validator; compare
+      inventory with the release checkout rather than requiring an obsolete
+      fixed minimum number of packs or documents
 - [ ] `Errors: 0 | Warnings: 0` → `VALIDATION PASSED`
 
 **Verify audit_skills.py:**
@@ -8349,7 +8473,7 @@ python3 scripts/audit_skills.py --ci
 ## Phase 6: Tests (3-5 min)
 
 ```bash
-# Run ONCE, capture to file, then parse. Full suite is 669+ bats cases —
+# Run ONCE, capture to file, then parse. Use the current release's Bats count;
 # re-running it per check (tail / grep ok / grep not ok piped separately)
 # wastes minutes every release. Always cache the output.
 npm test > /tmp/npm-test.log 2>&1
@@ -8362,7 +8486,7 @@ echo "exit:   $exit"
 
 **Verify:**
 - [ ] `exit == 0`
-- [ ] `ok == expected test count` (e.g., 945 on v3.0.0)
+- [ ] `ok == expected test count` from the current release's metadata contracts
 - [ ] `not ok == 0`
 - [ ] Bats runs tests in parallel (4 jobs)
 - [ ] Groups: agents, autodetect, cli, generators, guards, hooks, inject,
@@ -8473,7 +8597,7 @@ AI_TOOLKIT_STRICT_PIN=1 ai-toolkit update --dry-run
 
 These verify the native-surface generators shipped in v3.0.0 actually emit the right files for the right profiles, and that the tool registry stays in sync with shipped generators.
 
-> **Safety warning — HOME-scoped writes:** Running `--profile full` with `augment` in the editor list writes to `$HOME/.augment/settings.json` (Augment stores hooks under HOME, not per-project). Use `--dry-run` for verification unless you intend to carry ai-toolkit hook entries on this machine. The generator is marker-safe (only rewrites its own `_source: ai-toolkit` entries) but is still a side-effect.
+> Run this phase inside the disposable verification environment. `--profile full` with `augment` writes to `$HOME/.augment/settings.json`, so a temporary project on the operator's machine is insufficient. Dry-run checks cover the planned paths; Phases 9.4 and 9.5 must also exercise actual writes in isolation.
 
 ### 9.1 `--profile full` emits every native surface
 
@@ -8550,7 +8674,9 @@ The bats suite validates JSON shape at generation time. This re-checks that what
 D=/tmp/aitk-json-${RANDOM} && mkdir -p "$D" && cd "$D" && git init -q
 ai-toolkit install --local --editors cursor,windsurf,gemini,augment,codex,copilot --profile full >/dev/null 2>&1
 for f in .cursor/hooks.json .devin/hooks.v1.json .gemini/settings.json .codex/hooks.json .github/hooks/ai-toolkit.json "$HOME/.augment/settings.json"; do
-  [ -f "$f" ] && python3 -c "import json; json.load(open('$f'))" && echo "OK: $f"
+  [ -f "$f" ] || { echo "MISSING: $f"; exit 1; }
+  python3 -c 'import json, sys; json.load(open(sys.argv[1]))' "$f" || exit 1
+  echo "OK: $f"
 done
 ```
 
@@ -8682,9 +8808,9 @@ title: "SOP: Release Preparation"
 category: procedures
 service: ai-toolkit
 tags: [sop, release, version, publish, changelog, semver, provenance, sarif, ecosystem, shellcheck]
-version: "1.15.0"
+version: "1.15.1"
 created: "2026-04-10"
-last_updated: "2026-09-02"
+last_updated: "2026-09-06"
 description: "Step-by-step checklist for preparing a new ai-toolkit release — ecosystem-sync drift check, version sync, changelog, artifact regeneration, validation, branch CI, and tagging. Run BEFORE every git tag. Includes mandatory Provenance, SARIF, checksum-pin, ShellCheck, licensing, exact-tag assertions, and a green Ubuntu/macOS branch-CI gate before any release tag is created."
 ---
 
@@ -8693,6 +8819,13 @@ description: "Step-by-step checklist for preparing a new ai-toolkit release — 
 Complete checklist for preparing a new `@softspark/ai-toolkit` release.
 Run this **before** tagging. After tagging and publishing, run the
 [Release Verification SOP](sop-release-verification.md) to smoke-test.
+
+Installation smoke uses a disposable container or VM with its own default
+home directory, as described in the verification SOP. Test the packed release
+candidate before publishing and the exact npm version afterward. Keep the
+operator's installed toolkit, editor settings and authentication directories
+outside that environment. Compare component counts with the current release
+inventory and validator output instead of historical constants in a checklist.
 
 **Pipeline:**
 ```
@@ -9686,9 +9819,9 @@ title: "AI Toolkit - Architecture Overview"
 category: reference
 service: ai-toolkit
 tags: [architecture, overview, design, structure]
-version: "1.10.0"
+version: "1.10.1"
 created: "2026-03-23"
-last_updated: "2026-09-01"
+last_updated: "2026-09-06"
 description: "Architecture of ai-toolkit: install ownership, runtime adapters, the explicit DSH target, skill tiers, and project integration."
 ---
 
@@ -9998,7 +10131,7 @@ Agents (code-reviewer, debugger, devops-implementer, ...)
 
 ## Quality Hooks
 
-29 entries across 14 lifecycle events. See [hooks-catalog.md](hooks-catalog.md) for full details.
+28 entries across 14 lifecycle events. See [hooks-catalog.md](hooks-catalog.md) for full details.
 
 | Hook | Trigger | Script | Action |
 |------|---------|--------|--------|

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "4.32.3",
+  "version": "4.32.4",
   "components": {
     "agents": {
       "description": "44 specialized agents (orchestrator, backend, frontend, security, devops, etc.)",
@@ -12,7 +12,7 @@
       ]
     },
     "skills": {
-      "description": "109 skills (32 task + 31 hybrid + 46 knowledge)",
+      "description": "114 skills (32 task + 31 hybrid + 51 knowledge)",
       "path": "app/skills",
       "target": ".claude/skills",
       "type": "symlink",
@@ -137,7 +137,7 @@
       "default": true
     },
     "skills": {
-      "description": "109 skills (task, hybrid, knowledge)",
+      "description": "114 skills (task, hybrid, knowledge)",
       "default": true
     },
     "rules-common": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@softspark/ai-toolkit",
-  "version": "4.32.3",
+  "version": "4.32.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@softspark/ai-toolkit",
-      "version": "4.32.3",
+      "version": "4.32.4",
       "license": "Apache-2.0",
       "bin": {
         "ai-toolkit": "bin/ai-toolkit.js"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@softspark/ai-toolkit",
-  "version": "4.32.3",
-  "description": "AI coding toolkit: 109 skills, 44 agents, 14 developer-tool integrations, recoverable native tool-output filtering, Claude Chat/Cowork export, safety constitution, SARIF audit, and signed npm provenance.",
+  "version": "4.32.4",
+  "description": "AI coding toolkit: 114 skills, 44 agents, 14 developer-tool integrations, Claude Chat/Cowork export, safety constitution, SARIF audit, and signed npm provenance.",
   "keywords": [
     "claude",
     "claude-code",


### PR DESCRIPTION
## Summary

Prepare ai-toolkit 4.32.4 with guidance for matching frontend and backend validation, API error contracts and safe retries. The release also corrects JSON Schema/Ajv examples, synchronizes component descriptions and updates release procedures to test installed artifacts in disposable environments.

Synchronize the four version manifests, changelog, README, generated documentation and the reviewed ecosystem snapshot. No runtime generators, agent models, permissions, or protected public interfaces change.

## Test plan

- [x] Full local Bats suite for the validation changes: 1978/1978, no skips
- [x] Focused metadata, licensing and KB checks after release bookkeeping: 39/39
- [x] Final `validate.py --strict`: 0 errors and warnings, version 4.32.4
- [x] Skill evaluation 114/114, security audit HIGH 0 / WARN 0, SARIF 2.1.0
- [x] ShellCheck, Python syntax, checksum pins, offline ecosystem and public-surface gates
- [x] Final regeneration, reviewed diff and pre-commit scan
- [ ] Full Ubuntu/macOS CI on this release candidate
- [ ] Packed-candidate install and content checks in an isolated container
- [ ] After merge: exact main commit CI, then the single v4.32.4 tag and npm provenance/content verification

The current ruleset requires one CODEOWNER approval. Publication must wait for that approval and the tested release commit on main.
