### PR TITLE
chore: release v4.34.1

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -66,8 +66,8 @@ npm run typecheck:py   # mypy --strict over the allowlist in mypy.ini
 New tests for Python modules go to `tests/python/`; bats remains for hooks,
 CLI surfaces, and anything observed from a shell.
 
-If you touched any hook script, also run ShellCheck yourself — CI runs it, but
-`validate.py`, `npm test`, and the publish workflow do not:
+If you touched any hook script, also run ShellCheck yourself. CI and the publish
+workflow run it, but `validate.py` and `npm test` do not:
 
 ```bash
 shellcheck --severity=warning app/hooks/*.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## v4.34.1 - MCP endpoint configuration repair (2026-09-10)
+
+### Fixed
+
+- **MCP endpoint URLs:** resolve `${NAME}` and `${NAME:-default}` during native
+  config generation in `scripts/mcp_editors.py` and the OpenCode generator,
+  while preserving source templates and placeholders in headers and arguments.
+- **Local template updates:** refresh registered local MCP templates during
+  `ai-toolkit update` so stale generated endpoints are repaired; missing sources
+  and ownership collisions preserve installed configuration.
+
+### Verification
+
+- Add nine regression tests for endpoint resolution, canonical source
+  preservation, native adapters, atomic failure, and install/update behavior.
+- Keep the skill body budget unchanged: the largest body remains 17197 bytes,
+  above the threshold for the next ratchet reduction.
+
 ## v4.34.0 - Autonomous software delivery with RAG and Jira (2026-09-08)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -6,21 +6,16 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Skills](https://img.shields.io/badge/skills-116-brightgreen)](app/skills/)
 [![Agents](https://img.shields.io/badge/agents-44-blue)](app/agents/)
-[![Tests](https://img.shields.io/badge/tests-2014%20passing-success)](tests/)
+[![Tests](https://img.shields.io/badge/tests-2023%20passing-success)](tests/)
 
-## What's New in v4.34.0
+## What's New in v4.34.1
 
-**v4.34.0** adds autonomous software delivery to the 116-skill catalog:
-
-- **`/autonomous-dev`** takes a brief, specification, Jira task or existing PR
-  through implementation, review, validation, QA and required CI, with durable
-  ownership, bounded attempts and resumable evidence.
-- **`/prepare-test-env`** supplies shared application QA provenance, readiness
-  checks and narrowly owned cleanup.
-- **RAG and Jira profiles** separate task tracking, knowledge and code hosting;
-  refresh requirements on resume and reconcile remote-write receipts.
-- **PR preparation** uses actual project checks and safely resolves Git refs,
-  empty ranges and changed-file names.
+- **Working MCP URLs:** native editor configs receive resolved endpoint
+  addresses from `${NAME}` and `${NAME:-default}` template expressions.
+- **Local template refresh:** `ai-toolkit update` re-reads registered local MCP
+  templates, repairing stale generated configuration such as `rag-mcp-legal`.
+- **Source preservation:** portable templates, credential placeholders,
+  unrelated settings and missing-source configurations remain intact.
 
 See [CHANGELOG.md](CHANGELOG.md) for full history.
 

--- a/app/.claude-plugin/plugin.json
+++ b/app/.claude-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "ai-toolkit",
   "displayName": "AI Toolkit",
   "description": "Professional-grade engineering skills, agents, rules, and lifecycle guardrails for Claude Code, Claude Chat, and Cowork.",
-  "version": "4.34.0",
+  "version": "4.34.1",
   "author": {
     "name": "SoftSpark",
     "url": "https://github.com/softspark"

--- a/benchmarks/ecosystem-doctor-snapshot.json
+++ b/benchmarks/ecosystem-doctor-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "last_run": "2026-09-08T10:19:20Z",
+  "last_run": "2026-09-10T08:11:13Z",
   "schema_version": 1,
   "tools": {
     "aider": {
@@ -24,7 +24,7 @@
       }
     },
     "augment": {
-      "docs_hash": "d3017d1e2e9a921b",
+      "docs_hash": "c89553fa683bcd32",
       "headings": [
         "Admin",
         "Auggie CLI",
@@ -66,7 +66,7 @@
       }
     },
     "claude-app": {
-      "docs_hash": "c1a63abb43d3c98d",
+      "docs_hash": "63808399074dd530",
       "headings": [
         "Add global and folder instructions",
         "Availability",
@@ -108,7 +108,7 @@
       }
     },
     "claude-code": {
-      "docs_hash": "ef7e0a89823c3718",
+      "docs_hash": "8de8234ba28023b8",
       "headings": [
         "Core concepts",
         "Documentation Index",
@@ -174,10 +174,10 @@
         "userConfig": false,
         "workflows": true
       },
-      "version": "2.1.263 (Claude Code)"
+      "version": "2.1.267 (Claude Code)"
     },
     "cline": {
-      "docs_hash": "7e299697f4c33610",
+      "docs_hash": "8c3fc8dff5f90d1f",
       "headings": [
         "API Reference",
         "Best Practices",
@@ -225,7 +225,7 @@
       }
     },
     "codex-cli": {
-      "docs_hash": "9236502b676571e4",
+      "docs_hash": "68c2ca5e05c6840d",
       "headings": [
         "API",
         "API Reference",
@@ -365,10 +365,10 @@
         "plugin marketplace": false,
         "sandbox": true
       },
-      "version": "codex-cli 0.153.4"
+      "version": "codex-cli 0.154.0"
     },
     "cursor": {
-      "docs_hash": "b71a4e9a337185d3",
+      "docs_hash": "34ec3c9ac17a7745",
       "headings": [
         "Agent",
         "CLI",
@@ -401,7 +401,7 @@
       }
     },
     "dsh": {
-      "docs_hash": "217350a932acc7fb",
+      "docs_hash": "2f512e8581e200f5",
       "headings": [],
       "markers": {
         "Agent Preset": false,
@@ -412,7 +412,7 @@
       }
     },
     "gemini-cli": {
-      "docs_hash": "49e56808db7737d0",
+      "docs_hash": "2e10bdb9b1111411",
       "headings": [
         "Breadcrumbs",
         "Directory actions",
@@ -453,7 +453,7 @@
       "version": "0.57.0"
     },
     "github-copilot": {
-      "docs_hash": "7eb63b9012fbcf04",
+      "docs_hash": "f1456fd93502a652",
       "headings": [
         "About Copilot auto model selection",
         "About Copilot automations",
@@ -465,13 +465,12 @@
         "About cloud and local sandboxes for GitHub Copilot",
         "About custom agents",
         "Articles",
-        "Did you find what you needed?",
         "GitHub Copilot",
         "GitHub Copilot documentation",
         "Help and support",
-        "Help us make these docs great!",
-        "Legal",
-        "Still need help?"
+        "Help us make GitHub Docs great!",
+        "Still need help?",
+        "Was this Doc helpful?"
       ],
       "markers": {
         "AGENTS.md": false,
@@ -490,7 +489,7 @@
       }
     },
     "google-antigravity": {
-      "docs_hash": "8cbf9aaffb6b57bf",
+      "docs_hash": "9fe532d247c3e361",
       "headings": [],
       "markers": {
         "AGENTS.md": false,
@@ -517,7 +516,7 @@
       }
     },
     "opencode": {
-      "docs_hash": "8675f180c76f02dd",
+      "docs_hash": "c9f362f4e420a6d0",
       "headings": [
         "Add features",
         "Ask questions",
@@ -579,7 +578,7 @@
       }
     },
     "windsurf": {
-      "docs_hash": "c9f1d45fe190f606",
+      "docs_hash": "8c8b018f960b1a4d",
       "headings": [
         "Accounts",
         "Advanced",

--- a/kb/reference/extension-api.md
+++ b/kb/reference/extension-api.md
@@ -3,9 +3,9 @@ title: "Extension API Reference"
 category: reference
 service: ai-toolkit
 tags: [extension-api, inject-rule, inject-hook, inject-mcp, mcp-templates, integration, editors]
-version: "1.8.1"
+version: "1.9.0"
 created: "2026-04-07"
-last_updated: "2026-09-08"
+last_updated: "2026-09-10"
 description: "Reference for ai-toolkit's extension API: inject-rule, inject-hook, inject-mcp, remove-* variants, and editor-aware MCP template management."
 ---
 
@@ -208,6 +208,13 @@ Copilot (`$COPILOT_HOME/mcp-config.json`, default
 (`~/.augment/settings.json`), and Codex CLI (`$CODEX_HOME/config.toml`, default
 `~/.codex/config.toml`). Per-editor failures are non-fatal; the command reports
 a warning and continues.
+
+**Local source refresh:** Local file paths are registered too. `ai-toolkit update`
+re-reads those files and propagates them through the native adapters. Missing
+files warn and leave installed config intact; a local refresh never forces an
+ownership collision. Portable endpoint variables are resolved when rendering
+native configs, while `.mcp.json` retains the source expressions. See
+[Portable endpoint variables](mcp-templates.md#portable-endpoint-variables).
 
 **Idempotency:** Re-running with the same source overwrites entries for that source cleanly -- no duplicates accumulate.
 

--- a/kb/reference/mcp-templates.md
+++ b/kb/reference/mcp-templates.md
@@ -3,9 +3,9 @@ title: "MCP Server Templates"
 category: reference
 service: ai-toolkit
 tags: [mcp, templates, servers, configuration, editors, inject-mcp, external-templates]
-version: "1.6.0"
+version: "1.7.0"
 created: "2026-04-07"
-last_updated: "2026-08-31"
+last_updated: "2026-09-10"
 description: "Reference for 28 built-in MCP server templates, external template injection via inject-mcp, and native editor MCP installation support."
 ---
 
@@ -126,6 +126,26 @@ Each template is a JSON file with the following structure:
 `rag-mcp` and `rag-mcp-legal` expose unauthenticated HTTP MCP endpoints by
 design. Keep the default localhost binding, use a VPN, or protect remote access
 with a restricted reverse proxy.
+
+### Portable endpoint variables
+
+Native config generation resolves `${NAME}` and `${NAME:-default}` in endpoint
+fields (`url`, `serverUrl`, `httpUrl`), including the Claude app bridge and
+OpenCode. Resolution uses the environment of the install/update process.
+An unset or empty variable uses its default; without a default, rendering fails
+with the variable name and does not write that editor's config. Expansion is a
+single text substitution, with no shell execution or recursive expansion.
+
+For example, `${RAG_MCP_LEGAL_URL:-http://localhost:8082/mcp/sse}` becomes
+`http://localhost:8082/mcp/sse` when the variable is unset. Set
+`RAG_MCP_LEGAL_URL` before installing or updating to use another endpoint.
+The canonical `.mcp.json` and source templates retain the expression so later
+updates can resolve it again. Client-specific expressions such as `${env:NAME}`
+are preserved, as are placeholders in arguments, environment maps and headers.
+
+`ai-toolkit update` re-reads registered local MCP templates as well as URL
+sources. A missing local file emits a warning and preserves installed config;
+local refresh does not force ownership conflicts with another source.
 
 ## Example: Adding GitHub and PostgreSQL
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -13066,9 +13066,9 @@ title: "Extension API Reference"
 category: reference
 service: ai-toolkit
 tags: [extension-api, inject-rule, inject-hook, inject-mcp, mcp-templates, integration, editors]
-version: "1.8.1"
+version: "1.9.0"
 created: "2026-04-07"
-last_updated: "2026-09-08"
+last_updated: "2026-09-10"
 description: "Reference for ai-toolkit's extension API: inject-rule, inject-hook, inject-mcp, remove-* variants, and editor-aware MCP template management."
 ---
 
@@ -13271,6 +13271,13 @@ Copilot (`$COPILOT_HOME/mcp-config.json`, default
 (`~/.augment/settings.json`), and Codex CLI (`$CODEX_HOME/config.toml`, default
 `~/.codex/config.toml`). Per-editor failures are non-fatal; the command reports
 a warning and continues.
+
+**Local source refresh:** Local file paths are registered too. `ai-toolkit update`
+re-reads those files and propagates them through the native adapters. Missing
+files warn and leave installed config intact; a local refresh never forces an
+ownership collision. Portable endpoint variables are resolved when rendering
+native configs, while `.mcp.json` retains the source expressions. See
+[Portable endpoint variables](mcp-templates.md#portable-endpoint-variables).
 
 **Idempotency:** Re-running with the same source overwrites entries for that source cleanly -- no duplicates accumulate.
 
@@ -15496,9 +15503,9 @@ title: "MCP Server Templates"
 category: reference
 service: ai-toolkit
 tags: [mcp, templates, servers, configuration, editors, inject-mcp, external-templates]
-version: "1.6.0"
+version: "1.7.0"
 created: "2026-04-07"
-last_updated: "2026-08-31"
+last_updated: "2026-09-10"
 description: "Reference for 28 built-in MCP server templates, external template injection via inject-mcp, and native editor MCP installation support."
 ---
 
@@ -15619,6 +15626,26 @@ Each template is a JSON file with the following structure:
 `rag-mcp` and `rag-mcp-legal` expose unauthenticated HTTP MCP endpoints by
 design. Keep the default localhost binding, use a VPN, or protect remote access
 with a restricted reverse proxy.
+
+### Portable endpoint variables
+
+Native config generation resolves `${NAME}` and `${NAME:-default}` in endpoint
+fields (`url`, `serverUrl`, `httpUrl`), including the Claude app bridge and
+OpenCode. Resolution uses the environment of the install/update process.
+An unset or empty variable uses its default; without a default, rendering fails
+with the variable name and does not write that editor's config. Expansion is a
+single text substitution, with no shell execution or recursive expansion.
+
+For example, `${RAG_MCP_LEGAL_URL:-http://localhost:8082/mcp/sse}` becomes
+`http://localhost:8082/mcp/sse` when the variable is unset. Set
+`RAG_MCP_LEGAL_URL` before installing or updating to use another endpoint.
+The canonical `.mcp.json` and source templates retain the expression so later
+updates can resolve it again. Client-specific expressions such as `${env:NAME}`
+are preserved, as are placeholders in arguments, environment maps and headers.
+
+`ai-toolkit update` re-reads registered local MCP templates as well as URL
+sources. A missing local file emits a warning and preserves installed config;
+local refresh does not force ownership conflicts with another source.
 
 ## Example: Adding GitHub and PostgreSQL
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "4.34.0",
+  "version": "4.34.1",
   "components": {
     "agents": {
       "description": "44 specialized agents (orchestrator, backend, frontend, security, devops, etc.)",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@softspark/ai-toolkit",
-  "version": "4.34.0",
+  "version": "4.34.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@softspark/ai-toolkit",
-      "version": "4.34.0",
+      "version": "4.34.1",
       "license": "Apache-2.0",
       "bin": {
         "ai-toolkit": "bin/ai-toolkit.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@softspark/ai-toolkit",
-  "version": "4.34.0",
+  "version": "4.34.1",
   "description": "AI coding toolkit: 116 skills, 44 agents, 14 developer-tool integrations, autonomous software delivery, Claude Chat/Cowork export, safety constitution, SARIF audit, and signed npm provenance.",
   "keywords": [
     "claude",

--- a/scripts/ecosystem_tools.json
+++ b/scripts/ecosystem_tools.json
@@ -1,12 +1,14 @@
 {
   "schema_version": 1,
   "description": "Authoritative registry of tools ai-toolkit integrates with. Consumed by scripts/ecosystem_doctor.py to detect upstream doc/version drift.",
-  "last_updated": "2026-09-01",
+  "last_updated": "2026-09-10",
   "tools": [
     {
       "id": "claude-code",
       "display_name": "Claude Code",
       "kind": "primary",
+      "reviewed_version": "2.1.267",
+      "release_review_note": "2026-09-10 class C: maxEffortLevel and --system-prompt-snapshot are optional runtime controls, not adopted by toolkit generators. Existing emitted hooks, agents and plugin formats require no migration. Reviewed https://github.com/anthropics/claude-code/releases/tag/v2.1.267.",
       "urls": {
         "docs": "https://code.claude.com/docs",
         "release_notes": "https://github.com/anthropics/claude-code/releases",
@@ -645,6 +647,8 @@
       "id": "codex-cli",
       "display_name": "Codex CLI",
       "kind": "editor",
+      "reviewed_version": "0.154.0",
+      "release_review_note": "2026-09-10 class C: optional native worktrees, inline questions, Windows daemon and model-picker features are not adopted as generated configuration. Removal of codex mcp-server requires no toolkit migration: no generator, installer, skill or documented command uses that entry point. Reviewed https://github.com/openai/codex/releases/tag/rust-v0.154.0.",
       "urls": {
         "docs": "https://learn.chatgpt.com/docs/codex/cli",
         "release_notes": "https://github.com/openai/codex/releases",

--- a/scripts/generate_opencode_json.py
+++ b/scripts/generate_opencode_json.py
@@ -28,6 +28,8 @@ import json
 import sys
 from pathlib import Path
 
+from mcp_editors import resolve_endpoint_url
+
 SCHEMA_URL = "https://opencode.ai/config.json"
 
 
@@ -53,7 +55,7 @@ def _translate_server(name: str, server: dict) -> dict:
     out: dict = {}
     if "url" in server:
         out["type"] = "remote"
-        out["url"] = server["url"]
+        out["url"] = resolve_endpoint_url(server["url"])
         if "headers" in server and isinstance(server["headers"], dict):
             out["headers"] = copy.deepcopy(server["headers"])
     elif "command" in server:

--- a/scripts/install.py
+++ b/scripts/install.py
@@ -59,7 +59,7 @@ from emission import agent_count as count_agents, skill_count as count_skills
 # Step modules
 from install_steps.symlinks import install_agents, install_skills, clean_legacy_commands
 from install_steps.hooks import cleanup_retired_output_filter, install_hooks
-from install_steps.markers import install_marker_files, inject_rules, refresh_url_hooks, refresh_url_mcp
+from install_steps.markers import install_marker_files, inject_rules, refresh_url_hooks, refresh_mcp_templates
 from install_steps.ai_tools import install_ai_tools, install_local_project, run_script
 from install_steps.install_state import (
     record_install,
@@ -487,7 +487,7 @@ def install_claude_code(target_dir: Path, hooks_scripts_dir: Path,
 
     if not dry_run:
         refresh_url_hooks(str(target_dir))
-        refresh_url_mcp(str(target_dir))
+        refresh_mcp_templates(str(target_dir))
 
     _sync_mcp_templates(dry_run)
 

--- a/scripts/install_steps/markers.py
+++ b/scripts/install_steps/markers.py
@@ -262,25 +262,29 @@ def refresh_url_hooks(target_dir: str | None = None) -> None:
             inject(str(cached_file), target, source_override=hook_name)
 
 
-def refresh_url_mcp(target_dir: str | None = None) -> None:
-    """Re-fetch all URL-sourced MCP templates and re-inject them.
+def refresh_mcp_templates(target_dir: str | None = None) -> None:
+    """Re-read registered local and URL MCP templates and re-inject them.
 
-    Called during ``ai-toolkit update`` to keep URL-sourced MCP templates
-    current. On fetch failure, warns and keeps the cached version.
+    Called during ``ai-toolkit update``. URL fetch failures use the cached
+    version; missing local sources leave their installed config in place.
     """
-    from mcp_sources import get_url_templates, register_url_source
+    from mcp_sources import load_sources, register_url_source
     from paths import EXTERNAL_MCP_DIR
     from url_fetch import fetch_url
     import json
 
-    url_templates = get_url_templates()
-    if not url_templates:
+    sources = load_sources()
+    if not sources:
         return
 
-    print("  Refreshing URL-sourced MCP templates...")
+    print("  Refreshing external MCP templates...")
     target = target_dir or str(Path.home())
 
-    for template_name, url in url_templates.items():
+    for template_name, source in sources.items():
+        if "url" not in source:
+            _refresh_local_mcp_template(template_name, source, target)
+            continue
+        url = source["url"]
         cached_file = EXTERNAL_MCP_DIR / f"{template_name}.json"
         try:
             data = fetch_url(url)
@@ -300,6 +304,20 @@ def refresh_url_mcp(target_dir: str | None = None) -> None:
         if cached_file.is_file():
             from inject_mcp_cli import inject
             inject(str(cached_file), target, source_override=template_name, force=True)
+
+
+def _refresh_local_mcp_template(name: str, source: dict, target: str) -> None:
+    """Refresh a local source while preserving ownership and missing files."""
+    from inject_mcp_cli import inject
+
+    path = source.get("path")
+    if not isinstance(path, str) or not Path(path).is_file():
+        print(f"  Warning: local MCP template '{name}' is missing; keeping installed config.")
+        return
+    try:
+        inject(path, target, source_override=name, force=False)
+    except (Exception, SystemExit) as exc:
+        print(f"  Warning: could not refresh local MCP template '{name}': {exc}")
 
 
 def _inject_rules_dry_run(rules_dir: Path) -> None:

--- a/scripts/mcp_editors.py
+++ b/scripts/mcp_editors.py
@@ -121,6 +121,7 @@ CODEX_MCP_BLOCK_START = "# >>> ai-toolkit managed Codex MCP servers >>>"
 CODEX_MCP_BLOCK_END = "# <<< ai-toolkit managed Codex MCP servers <<<"
 
 _TOML_BARE_KEY_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+_ENDPOINT_ENV_RE = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-([^{}]*))?\}")
 _CODEX_SHARED_SERVER_KEYS = frozenset(
     {
         "startup_timeout_sec",
@@ -560,7 +561,28 @@ def _rollback_config_update(update: ConfigUpdate) -> None:
     _atomic_write_bytes(update.path, update.original)
 
 
+def resolve_endpoint_url(value: str) -> str:
+    """Resolve portable endpoint variables once, without executing shell code."""
+    def replace(match: re.Match[str]) -> str:
+        name, default = match.groups()
+        resolved = os.environ.get(name) or default
+        if resolved is None:
+            raise ValueError(f"MCP endpoint environment variable '{name}' is unset or empty")
+        return resolved
+
+    return _ENDPOINT_ENV_RE.sub(replace, value)
+
+
+def _resolve_server_endpoints(server: dict) -> dict:
+    data = copy.deepcopy(server)
+    for key in ("url", "serverUrl", "httpUrl"):
+        if isinstance(data.get(key), str):
+            data[key] = resolve_endpoint_url(data[key])
+    return data
+
+
 def _normalize_server(editor: str, server: dict) -> dict:
+    server = _resolve_server_endpoints(server)
     if editor == "antigravity":
         return _normalize_antigravity_server(server)
     if editor == "claude-app":
@@ -733,7 +755,12 @@ def _prepare_merge_json_servers(
     if not isinstance(bucket, dict):
         raise ValueError(f"{path} has invalid mcpServers data")
     for key, value in servers.items():
-        bucket[key] = _normalize_server(editor, value)
+        # Claude's project config is also the portable source for later syncs.
+        bucket[key] = (
+            copy.deepcopy(value)
+            if editor == "claude" and path.name == ".mcp.json"
+            else _normalize_server(editor, value)
+        )
     content = (json.dumps(data, indent=2) + "\n").encode("utf-8")
     return ConfigUpdate(path=path, original=original, content=content)
 
@@ -803,7 +830,7 @@ def _normalize_toml_server(server: dict) -> dict:
     if not isinstance(server, dict):
         raise ValueError("Codex MCP server configuration must be an object")
 
-    source = copy.deepcopy(server)
+    source = _resolve_server_endpoints(server)
     source.pop("_source", None)
     _strip_compatible_codex_transport_type(source)
     if "tools" in source and not isinstance(source["tools"], dict):

--- a/scripts/mcp_sources.py
+++ b/scripts/mcp_sources.py
@@ -158,9 +158,3 @@ def unregister_source(mcp_dir: Path | None, template_name: str) -> bool:
         save_sources(mcp_dir, sources)
         return True
     return False
-
-
-def get_url_templates(mcp_dir: Path | None = None) -> dict[str, str]:
-    """Return {template_name: url} for all URL-sourced MCP templates."""
-    sources = load_sources(mcp_dir)
-    return {name: entry["url"] for name, entry in sources.items() if "url" in entry}

--- a/tests/test_mcp_url_resolution.bats
+++ b/tests/test_mcp_url_resolution.bats
@@ -1,0 +1,279 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2024-2026 Lukasz Krzemien (biuro@softspark.eu)
+# Source: https://github.com/softspark/ai-toolkit
+
+TOOLKIT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+
+setup() {
+    TEST_HOME="$BATS_TEST_TMPDIR/home"
+    mkdir -p "$TEST_HOME"
+}
+
+run_python() {
+    run env -u CODEX_HOME -u COPILOT_HOME -u CLAUDE_USER_DATA_DIR \
+        HOME="$TEST_HOME" SOFTSPARK_HOME="$TEST_HOME/.softspark" \
+        AI_TOOLKIT_HOME="$TEST_HOME/.softspark/ai-toolkit" \
+        PYTHONPATH="$TOOLKIT_DIR/scripts" python3 - "$TEST_HOME" "$TOOLKIT_DIR"
+}
+
+@test "endpoint resolver supports portable defaults without recursive or native expansion" {
+    run_python <<'PY'
+import os
+from mcp_editors import resolve_endpoint_url
+
+os.environ.pop("MCP_TEST_ENDPOINT", None)
+default = "http://localhost:8082/mcp/sse"
+expression = "${MCP_TEST_ENDPOINT:-" + default + "}"
+assert resolve_endpoint_url(expression) == default
+os.environ["MCP_TEST_ENDPOINT"] = ""
+assert resolve_endpoint_url(expression) == default
+os.environ["MCP_TEST_ENDPOINT"] = "https://custom.example/mcp"
+assert resolve_endpoint_url(expression) == "https://custom.example/mcp"
+assert resolve_endpoint_url("${MCP_TEST_ENDPOINT}") == "https://custom.example/mcp"
+assert resolve_endpoint_url("${env:MCP_TEST_ENDPOINT}") == "${env:MCP_TEST_ENDPOINT}"
+os.environ["MCP_TEST_ENDPOINT"] = "${MCP_TEST_NESTED:-secret}"
+assert resolve_endpoint_url("${MCP_TEST_ENDPOINT}") == "${MCP_TEST_NESTED:-secret}"
+assert resolve_endpoint_url(default) == default
+PY
+    [ "$status" -eq 0 ]
+}
+
+@test "missing portable endpoint variable fails without revealing endpoint credentials" {
+    run_python <<'PY'
+import os
+from mcp_editors import resolve_endpoint_url
+
+os.environ.pop("MCP_TEST_MISSING", None)
+endpoint = "https://private-user:private-password@example.test/${MCP_TEST_MISSING}?token=private-token"
+try:
+    resolve_endpoint_url(endpoint)
+except ValueError as error:
+    message = str(error)
+    assert "MCP_TEST_MISSING" in message, message
+    for private in ("private-user", "private-password", "example.test", "private-token"):
+        assert private not in message, message
+else:
+    raise AssertionError("missing endpoint variable must fail")
+PY
+    [ "$status" -eq 0 ]
+}
+
+@test "native adapters resolve endpoint fields without changing template or unrelated placeholders" {
+    run_python <<'PY'
+import copy
+import json
+import os
+import sys
+import tomllib
+from pathlib import Path
+from mcp_editors import install_servers, resolve_editor_path
+
+home = Path(sys.argv[1])
+os.environ.pop("MCP_TEST_ENDPOINT", None)
+url = "http://localhost:8082/mcp/sse"
+placeholder = "${MCP_TEST_ENDPOINT:-" + url + "}"
+for editor, field in (("codex", "url"), ("cursor", "url"), ("antigravity", "serverUrl"), ("gemini", "httpUrl"), ("claude-app", "url")):
+    servers = {"legal": {field: placeholder}}
+    original = copy.deepcopy(servers)
+    install_servers([editor], servers, scope="global", home=home)
+    assert servers == original, editor
+    path = resolve_editor_path(editor, "global", home=home)
+    if editor == "codex":
+        actual = tomllib.loads(path.read_text())["mcp_servers"]["legal"]
+    else:
+        actual = json.loads(path.read_text())["mcpServers"]["legal"]
+    if editor == "claude-app":
+        assert url in actual["args"], actual
+    else:
+        assert actual[field] == url, (editor, actual)
+    before = path.read_bytes()
+    install_servers([editor], servers, scope="global", home=home)
+    assert path.read_bytes() == before, editor
+
+servers = {
+    "remote": {"url": placeholder, "headers": {"Authorization": "${MCP_TEST_TOKEN}"}},
+    "local": {"command": "echo", "args": ["${MCP_TEST_ARG}"], "env": {"TOKEN": "${MCP_TEST_TOKEN}"}},
+}
+install_servers(["cursor"], servers, scope="global", home=home)
+actual = json.loads((home / ".cursor/mcp.json").read_text())["mcpServers"]
+assert actual["remote"]["headers"] == servers["remote"]["headers"]
+assert actual["local"]["args"] == servers["local"]["args"]
+assert actual["local"]["env"] == servers["local"]["env"]
+install_servers(["claude", "codex"], {"legal": {"url": placeholder}}, scope="project", project_dir=home)
+canonical = json.loads((home / ".mcp.json").read_text())
+assert canonical["mcpServers"]["legal"]["url"] == placeholder
+PY
+    [ "$status" -eq 0 ]
+}
+
+@test "inject CLI repairs stale managed Codex endpoint and preserves canonical expression and comments" {
+    run_python <<'PY'
+import json
+import os
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+from mcp_editors import CODEX_MCP_BLOCK_START, CODEX_MCP_BLOCK_END
+
+home, toolkit = map(Path, sys.argv[1:])
+os.environ.pop("RAG_MCP_LEGAL_URL", None)
+expression = "${RAG_MCP_LEGAL_URL:-http://localhost:8082/mcp/sse}"
+template = home / "legal.json"
+template.write_text(json.dumps({"mcpServers": {"rag-mcp-legal": {"type": "http", "url": expression}}}))
+original = template.read_bytes()
+config = home / ".codex/config.toml"
+config.parent.mkdir()
+prefix = '# user comment\npersonality = "pragmatic" # preserve inline comment\n'
+config.write_text(prefix + CODEX_MCP_BLOCK_START + '\n[mcp_servers.rag-mcp-legal]\nurl = "' + expression + '"\n' + CODEX_MCP_BLOCK_END + '\n')
+command = [sys.executable, str(toolkit / "scripts/inject_mcp_cli.py"), str(template), str(home)]
+subprocess.run(command, check=True, capture_output=True, text=True)
+assert config.read_text().startswith(prefix)
+assert tomllib.loads(config.read_text())["mcp_servers"]["rag-mcp-legal"]["url"] == "http://localhost:8082/mcp/sse"
+assert json.loads((home / ".mcp.json").read_text())["mcpServers"]["rag-mcp-legal"]["url"] == expression
+assert template.read_bytes() == original
+before = config.read_bytes()
+subprocess.run(command, check=True, capture_output=True, text=True)
+assert config.read_bytes() == before
+PY
+    [ "$status" -eq 0 ]
+}
+
+@test "refresh re-reads registered local template and repairs stale Codex URL without losing comments" {
+    run_python <<'PY'
+import json
+import os
+import sys
+import tomllib
+from pathlib import Path
+from inject_mcp_cli import inject
+from install_steps.markers import refresh_mcp_templates
+from mcp_sources import register_path_source
+
+home = Path(sys.argv[1])
+os.environ.pop("RAG_MCP_LEGAL_URL", None)
+template = home / "legal.json"
+template.write_text(json.dumps({"mcpServers": {"rag-mcp-legal": {"url": "http://localhost:8082/mcp/sse"}}}))
+inject(str(template), str(home))
+config = home / ".codex/config.toml"
+config.write_text('# keep me\n' + config.read_text().replace("http://localhost:8082/mcp/sse", "${RAG_MCP_LEGAL_URL:-http://localhost:8082/mcp/sse}"))
+template.write_text(json.dumps({"mcpServers": {"rag-mcp-legal": {"url": "${RAG_MCP_LEGAL_URL:-http://localhost:9082/mcp/sse}"}}}))
+register_path_source(None, "missing", home / "does-not-exist.json")
+refresh_mcp_templates(str(home))
+assert config.read_text().startswith('# keep me\n')
+assert tomllib.loads(config.read_text())["mcp_servers"]["rag-mcp-legal"]["url"] == "http://localhost:9082/mcp/sse"
+PY
+    [ "$status" -eq 0 ]
+    [[ "$output" == *Warning* || "$output" == *warning* ]]
+    [[ "$output" == *missing* || "$output" == *does-not-exist* ]]
+}
+
+@test "OpenCode generation resolves endpoint and preserves canonical placeholders" {
+    run_python <<'PY'
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+home, toolkit = map(Path, sys.argv[1:])
+os.environ.pop("MCP_TEST_ENDPOINT", None)
+canonical = home / ".mcp.json"
+canonical.write_text(json.dumps({"mcpServers": {"legal": {
+    "type": "http", "url": "${MCP_TEST_ENDPOINT:-http://localhost:8082/mcp/sse}",
+    "headers": {"Authorization": "${MCP_TEST_TOKEN}"},
+}}}))
+before = canonical.read_bytes()
+command = [sys.executable, str(toolkit / "scripts/generate_opencode_json.py"), str(home)]
+subprocess.run(command, check=True, capture_output=True, text=True)
+actual = json.loads((home / "opencode.json").read_text())["mcp"]["legal"]
+assert actual["url"] == "http://localhost:8082/mcp/sse", actual
+assert actual["headers"]["Authorization"] == "${MCP_TEST_TOKEN}", actual
+assert canonical.read_bytes() == before
+PY
+    [ "$status" -eq 0 ]
+}
+
+@test "global install CLI refreshes registered local MCP sources on update" {
+    run_python <<'PY'
+import json
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+from mcp_sources import register_path_source
+
+home, toolkit = map(Path, sys.argv[1:])
+template = home / "legal.json"
+template.write_text(json.dumps({"mcpServers": {"legal": {"url": "http://localhost:8082/mcp/sse"}}}))
+register_path_source(None, "legal", template)
+command = [sys.executable, str(toolkit / "scripts/install.py"), str(home), "--only", "rules"]
+subprocess.run(command, check=True, capture_output=True, text=True, cwd=home)
+config = home / ".codex/config.toml"
+assert tomllib.loads(config.read_text())["mcp_servers"]["legal"]["url"] == "http://localhost:8082/mcp/sse"
+template.write_text(json.dumps({"mcpServers": {"legal": {"url": "http://localhost:9182/mcp/sse"}}}))
+subprocess.run(command, check=True, capture_output=True, text=True, cwd=home)
+assert tomllib.loads(config.read_text())["mcp_servers"]["legal"]["url"] == "http://localhost:9182/mcp/sse"
+PY
+    [ "$status" -eq 0 ]
+}
+
+@test "unresolved endpoint aborts native installation without changing any existing config" {
+    run_python <<'PY'
+import os
+import sys
+from pathlib import Path
+from mcp_editors import install_servers
+
+home = Path(sys.argv[1])
+os.environ.pop("MCP_TEST_MISSING", None)
+paths = [home / ".codex/config.toml", home / ".cursor/mcp.json"]
+for path, content in zip(paths, ['# user comment\n[mcp_servers.user]\ncommand = "true"\n', '{"mcpServers":{"user":{"command":"true"}}}\n']):
+    path.parent.mkdir()
+    path.write_text(content)
+before = [path.read_bytes() for path in paths]
+try:
+    install_servers(["cursor", "codex"], {"legal": {"url": "${MCP_TEST_MISSING}"}}, scope="global", home=home)
+except ValueError:
+    pass
+else:
+    raise AssertionError("missing endpoint must abort native installation")
+assert [path.read_bytes() for path in paths] == before
+PY
+    [ "$status" -eq 0 ]
+}
+
+@test "local refresh preserves missing-source config and never forces source ownership conflicts" {
+    run_python <<'PY'
+import contextlib
+import io
+import json
+import sys
+from pathlib import Path
+from install_steps.markers import refresh_mcp_templates
+from mcp_sources import register_path_source
+
+home = Path(sys.argv[1])
+canonical = home / ".mcp.json"
+data = {"mcpServers": {
+    "legal": {"url": "https://user.example/mcp", "_source": "user-source"},
+    "missing": {"url": "https://missing.example/mcp", "_source": "missing"},
+}}
+canonical.write_text(json.dumps(data))
+template = home / "legal.json"
+template.write_text(json.dumps({"mcpServers": {"legal": {"url": "http://localhost:8082/mcp/sse"}}}))
+register_path_source(None, "missing", home / "does-not-exist.json")
+register_path_source(None, "legal", template)
+before = canonical.read_bytes()
+output = io.StringIO()
+with contextlib.redirect_stdout(output), contextlib.redirect_stderr(output):
+    try:
+        refresh_mcp_templates(str(home))
+    except SystemExit as error:
+        assert error.code != 0
+assert canonical.read_bytes() == before
+assert "missing" in output.getvalue() or "does-not-exist" in output.getvalue(), output.getvalue()
+PY
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

Injected MCP templates could leave `${RAG_MCP_LEGAL_URL:-http://localhost:8082/mcp/sse}` literally in Codex configuration, preventing connection to a healthy server. Release 4.34.1 resolves portable endpoint variables when generating native configs and refreshes registered local templates during `ai-toolkit update`.

Source expressions, credential placeholders, unrelated editor settings and missing-source configurations are preserved. Nine regression tests cover adapters, actual install/update commands, idempotence and atomic failure.

## Type of Change

- [x] Bug fix
- [x] Test improvement
- [x] Maintainer release: 4.34.1

## Validation

- [x] Bats: 2023/2023 passed on the release candidate.
- [x] GitHub CI: all nine jobs passed, including the Ubuntu/macOS Bats matrix (run 34454948238).
- [x] Python: 358 tests, Ruff and strict mypy allowlist passed.
- [x] ShellCheck, strict toolkit validation, skill evaluation and pre-commit scan passed.
- [x] Security audit: 0 HIGH / 0 WARN; SARIF and publish provenance configuration verified.
- [x] Public surface: all 289 protected entries retained.
- [x] Ecosystem review: 14 clean targets after class A/C baseline refresh.
- [x] Packed candidate: 55 runtime smoke gates passed in a container without host mounts, including doctor, native editor generation and MCP repair.
- [x] Second clean-container run: all 55 smoke gates passed and host fingerprints were byte-identical. First-window `.claude.json` difference was limited to `promptQueueUseCount`, confirmed by backup comparison; evidence is retained. Both containers had no host mounts or shared namespaces.

## Notes for Maintainer

Version manifests, README and generated documentation were intentionally updated under the release SOP. Skill body budget remains unchanged: largest body 17197 bytes. No new runtime dependency or skill permission was introduced.

Release remains gated on CODEOWNER approval and required PR checks, followed by complete Ubuntu/macOS push CI for the merged main SHA before tagging. Published-package provenance and isolated npm smoke follow the publish workflow.
